### PR TITLE
Close memory leak in getsockaddr

### DIFF
--- a/src/ext/oblivc/obliv_bits.c
+++ b/src/ext/oblivc/obliv_bits.c
@@ -196,11 +196,11 @@ void protocolUseTcp2P(ProtocolDesc* pd,int sock,bool isClient)
 
 static int getsockaddr(const char* name,const char* port, struct sockaddr* res)
 {
-  struct addrinfo* list;
+  struct addrinfo *list, *iter;
   if(getaddrinfo(name,port,NULL,&list) < 0) return -1;
-  for(;list!=NULL && list->ai_family!=AF_INET;list=list->ai_next);
-  if(!list) return -1;
-  memcpy(res,list->ai_addr,list->ai_addrlen);
+  for(iter=list;iter!=NULL && iter->ai_family!=AF_INET;iter=iter->ai_next);
+  if(!iter) { freeaddrinfo(list); return -1; }
+  memcpy(res,iter->ai_addr,iter->ai_addrlen);
   freeaddrinfo(list);
   return 0;
 }


### PR DESCRIPTION
Fixes a memory leak in `getsockaddr` that arises when the first element in the list allocated by `freeaddrinfo` does not satisfy `.ai_family == AF_INET`.
