### PR TITLE
Fixes for integer overflows, plus protocol splitting

### DIFF
--- a/src/ext/oblivc/obliv.h
+++ b/src/ext/oblivc/obliv.h
@@ -18,6 +18,7 @@ void protocolAddSizeCheck(ProtocolDesc* pd);
 int protocolConnectTcp2P(ProtocolDesc* pd,const char* server,const char* port);
 int protocolAcceptTcp2P(ProtocolDesc* pd,const char* port);
 void cleanupProtocol(ProtocolDesc*);
+void splitProtocol(ProtocolDesc*, ProtocolDesc*);
 
 void setCurrentParty(ProtocolDesc* pd, int party);
 void execDebugProtocol(ProtocolDesc* pd, protocol_run start, void* arg);
@@ -32,5 +33,6 @@ bool execNpProtocol_Bcast1(ProtocolDesc* pd, protocol_run start, void* arg);
 void execNnobProtocol(ProtocolDesc* pd, protocol_run start, void* arg, int numOTs, bool useAltOTExt);
 
 size_t tcp2PBytesSent(ProtocolDesc* pd);
+int tcp2PFlushCount(ProtocolDesc* pd);
 
 #endif // OBLIV_H

--- a/src/ext/oblivc/obliv_bits.c
+++ b/src/ext/oblivc/obliv_bits.c
@@ -886,11 +886,13 @@ void splitYaoProtocolExtra(ProtocolDesc* pdout, ProtocolDesc * pdin) {
   ypdout->extra = NULL;
   ypdout->fixedKeyCipher = ypdin->fixedKeyCipher;
   if (pdout->thisParty == 1) {
-    gcry_randomize(ypdout->R,YAO_KEY_BYTES,GCRY_STRONG_RANDOM);
+    gcry_randomize(&ypdout->gcount,sizeof(ypdout->gcount),GCRY_STRONG_RANDOM);
+    osend(pdin,1,&ypdout->gcount,sizeof(ypdout->gcount));
+    memcpy(ypdout->R,ypdin->R,YAO_KEY_BYTES);
     gcry_randomize(ypdout->I,YAO_KEY_BYTES,GCRY_STRONG_RANDOM);
-    ypdout->R[0] |= 1;   // flipper bit // NOTE: ASSUME POINT AND PERMUTE IS TRUE
     //ypdout->sender = honestOTExtSenderAbstract(honestOTExtSenderNew(pdout,2));
   } else {
+    orecv(pdin,2,&ypdout->gcount,sizeof(ypdout->gcount));
     //ypdout->recver = honestOTExtRecverAbstract(honestOTExtRecverNew(pdout,1));
   }
   pdout->extra=ypdout;

--- a/src/ext/oblivc/obliv_bits.c
+++ b/src/ext/oblivc/obliv_bits.c
@@ -56,7 +56,6 @@ static struct stdioTransport stdioTransport
 void protocolUseStdio(ProtocolDesc* pd)
   { pd->trans = &stdioTransport.cb; }
 
-//#define PROFILE_NETWORK
 // TCP connections for 2-Party protocols. Ignores src/dest parameters
 //   since there is only one remote
 typedef struct tcp2PTransport
@@ -67,26 +66,16 @@ typedef struct tcp2PTransport
   bool needFlush;
   bool keepAlive;
   int sinceFlush;
-#ifdef PROFILE_NETWORK
   size_t bytes;
   int flushCount;
   struct tcp2PTransport* parent;
-#endif
 } tcp2PTransport;
 
 size_t tcp2PBytesSent(ProtocolDesc* pd) 
-#ifdef PROFILE_NETWORK
   { return ((tcp2PTransport*)(pd->trans))->bytes; }
-#else
-  { return 0; }
-#endif
 
 int tcp2PFlushCount(ProtocolDesc* pd)
-#ifdef PROFILE_NETWORK
   { return ((tcp2PTransport*)(pd->trans))->flushCount; }
-#else
-  { return 0; }
-#endif
 
 static int tcp2PSend(ProtocolTransport* pt,int dest,const void* s,size_t n)
 { struct tcp2PTransport* tcpt = CAST(pt);
@@ -96,17 +85,13 @@ static int tcp2PSend(ProtocolTransport* pt,int dest,const void* s,size_t n)
 	/*int res = write(tcpt->sock,n2+(char*)s,n-n2);*/
 	/*if(res<=0) { perror("TCP write error: "); return res; }*/
 	/*n2+=res;*/
-/*#ifdef PROFILE_NETWORK*/
 	/*tcpt->bytes += res;*/
-/*#endif*/
   /*}*/
   while(n>n2) {
 	int res = fwrite(n2+(char*)s,1,n-n2,tcpt->sockStream);
 	if(res<0) { perror("TCP write error: "); return res; }
 	n2+=res;
-#ifdef PROFILE_NETWORK
 	tcpt->bytes += res;
-#endif
   }
   return n2;
 }
@@ -117,9 +102,7 @@ static int tcp2PRecv(ProtocolTransport* pt,int src,void* s,size_t n)
 	if(tcpt->needFlush)
 	{
 		fflush(tcpt->sockStream);	
-#ifdef PROFILE_NETWORK
-                tcpt->flushCount++;
-#endif
+    tcpt->flushCount++;
 		tcpt->needFlush=false;
 	}
   /*while(n>n2)*/
@@ -141,17 +124,11 @@ static void tcp2PCleanup(ProtocolTransport* pt)
   fflush(t->sockStream);
   if(!t->keepAlive)
     fclose(t->sockStream);
-#ifdef PROFILE_NETWORK
   t->flushCount++;
-  if(t->parent==NULL)
-  { fprintf(stderr,"Total bytes sent: %zd\n",t->bytes);
-    fprintf(stderr,"Total flush done: %d\n",t->flushCount);
-  }
-  else
+  if(t->parent!=NULL)
   { t->parent->bytes+=t->bytes;
     t->parent->flushCount+=t->flushCount;
   }
-#endif
   free(pt);
 }
 
@@ -164,18 +141,11 @@ FILE* transGetFile(ProtocolTransport* t)
 }
 static ProtocolTransport* tcp2PSplit(ProtocolTransport* tsrc);
 
-#ifdef PROFILE_NETWORK
 static const tcp2PTransport tcp2PTransportTemplate
   = {{.maxParties=2, .split=tcp2PSplit, .send=tcp2PSend, .recv=tcp2PRecv,
       .cleanup = tcp2PCleanup},
      .sock=0, .isClient=0, .needFlush=false, .bytes=0, .flushCount=0,
      .parent=NULL};
-#else
-static const tcp2PTransport tcp2PTransportTemplate
-  = {{.maxParties=2, .split=tcp2PSplit, .send=tcp2PSend, .recv=tcp2PRecv,
-      .cleanup = tcp2PCleanup},
-    .sock=0, .isClient=0, .needFlush=false};
-#endif
 
 // isClient value will only be used for the split() method, otherwise
 // its value doesn't matter. In that case, it indicates which party should be
@@ -294,9 +264,7 @@ static int sockSplit(int sock,ProtocolTransport* t,bool isClient)
     //if(write(sock,&sa.sin_port,sizeof(sa.sin_port))<0) return -1;
     if(transSend(t,0,&sa.sin_port,sizeof(sa.sin_port))<0) return -1;
     fflush(((tcp2PTransport*)t)->sockStream); 
-#ifdef PROFILE_NETWORK
     ((tcp2PTransport*)t)->flushCount++;
-#endif
     int newsock = accept(listenSock,0,0);
     close(listenSock);
     return newsock;
@@ -307,19 +275,13 @@ static ProtocolTransport* tcp2PSplit(ProtocolTransport* tsrc)
 {
   tcp2PTransport* t = CAST(tsrc);
   fflush(t->sockStream); 
-#ifdef PROFILE_NETWORK
   ((tcp2PTransport*)t)->flushCount++;
-#endif
   // I should really rewrite sockSplit to use FILE* sockStream
   int newsock = sockSplit(t->sock,tsrc,t->isClient);
   if(newsock<0) { fprintf(stderr,"sockSplit() failed\n"); return NULL; }
-#ifdef PROFILE_NETWORK
   if(!t->isClient) t->bytes+=sizeof(in_port_t);
-#endif
   tcp2PTransport* tnew = tcp2PNew(newsock,t->isClient);
-#ifdef PROFILE_NETWORK
   tnew->parent=t;
-#endif
   return CAST(tnew);
 }
 
@@ -899,6 +861,41 @@ void yaoReleaseOt(ProtocolDesc* pd,int me)
   if(me==1) otSenderRelease(&ypd->sender);
   else otRecverRelease(&ypd->recver);
 }
+
+void splitProtocol(ProtocolDesc* pdout, ProtocolDesc * pdin) {
+  pdout->error= pdin->error;
+  pdout->partyCount = pdin->partyCount;
+  pdout->currentParty = pdin->currentParty;
+  pdout->feedOblivInputs = pdin->feedOblivInputs;
+  pdout->revealOblivBits = pdin->revealOblivBits;
+  pdout->setBitAnd = pdin->setBitAnd;
+  pdout->setBitOr = pdin->setBitOr;
+  pdout->setBitXor = pdin->setBitXor;
+  pdout->setBitNot = pdin->setBitNot;
+  pdout->flipBit = pdin->flipBit;
+  pdout->thisParty = pdin->thisParty;
+  pdout->trans = pdin->trans->split(pdin->trans);
+  pdout->copyextra = pdin->copyextra;
+  pdout->copyextra(pdout, pdin);
+}
+
+void splitYaoProtocolExtra(ProtocolDesc* pdout, ProtocolDesc * pdin) {
+  YaoProtocolDesc* ypdin = pdin->extra;
+  YaoProtocolDesc* ypdout = malloc(sizeof(YaoProtocolDesc));
+  ypdout->protoType = ypdin->protoType;
+  ypdout->extra = NULL;
+  ypdout->fixedKeyCipher = ypdin->fixedKeyCipher;
+  if (pdout->thisParty == 1) {
+    gcry_randomize(ypdout->R,YAO_KEY_BYTES,GCRY_STRONG_RANDOM);
+    gcry_randomize(ypdout->I,YAO_KEY_BYTES,GCRY_STRONG_RANDOM);
+    ypdout->R[0] |= 1;   // flipper bit // NOTE: ASSUME POINT AND PERMUTE IS TRUE
+    //ypdout->sender = honestOTExtSenderAbstract(honestOTExtSenderNew(pdout,2));
+  } else {
+    //ypdout->recver = honestOTExtRecverAbstract(honestOTExtRecverNew(pdout,1));
+  }
+  pdout->extra=ypdout;
+}
+
 /* execYaoProtocol is divided into 2 parts which are reused by other
    protocols such as DualEx */
 void setupYaoProtocol(ProtocolDesc* pd,bool halfgates)
@@ -929,8 +926,12 @@ void setupYaoProtocol(ProtocolDesc* pd,bool halfgates)
   else ypd->recver.recver=NULL;
 
   dhRandomInit();
+
+  //TODO: why is this ECB?
   gcry_cipher_open(&ypd->fixedKeyCipher,yaoFixedKeyAlgo,GCRY_CIPHER_MODE_ECB,0);
   gcry_cipher_setkey(ypd->fixedKeyCipher,yaoFixedKey,sizeof(yaoFixedKey)-1);
+
+  pd->copyextra = splitYaoProtocolExtra;
 }
 
 // point_and_permute should always be true.

--- a/src/ext/oblivc/obliv_bits.c
+++ b/src/ext/oblivc/obliv_bits.c
@@ -587,12 +587,12 @@ void yaoGenrFeedOblivInputs(ProtocolDesc* pd
     o->yao.inverted = false; o->unknown = true;
     yaoKeyCopy(o->yao.w,w0);
   }else 
-  { int bc = bitCount(&it);
+  { size_t bc = bitCount(&it);
     // limit memory usage
-    int batch = (bc<YAO_FEED_MAX_BATCH?bc:YAO_FEED_MAX_BATCH);
+    size_t batch = (bc<YAO_FEED_MAX_BATCH?bc:YAO_FEED_MAX_BATCH);
     char *buf0 = malloc(batch*YAO_KEY_BYTES),
          *buf1 = malloc(batch*YAO_KEY_BYTES);
-    int bp=0;
+    size_t bp=0;
     for(;hasBit(&it);nextBit(&it))
     { 
       OblivBit* o = curDestBit(&it);
@@ -621,13 +621,13 @@ void yaoEvalFeedOblivInputs(ProtocolDesc* pd
     o->unknown = true;
     ypd->icount++;
   }else 
-  { int bc = bitCount(&it);
+  { size_t bc = bitCount(&it);
     // limit memory usage
-    int batch = (bc<YAO_FEED_MAX_BATCH?bc:YAO_FEED_MAX_BATCH);
+    size_t batch = (bc<YAO_FEED_MAX_BATCH?bc:YAO_FEED_MAX_BATCH);
     char *buf = malloc(batch*YAO_KEY_BYTES),
          **dest = malloc(batch*sizeof(char*));
     bool *sel = malloc(batch*sizeof(bool));
-    int bp=0,i;
+    size_t bp=0,i;
     for(;hasBit(&it);nextBit(&it))
     { OblivBit* o = curDestBit(&it);
       dest[bp]=o->yao.w;
@@ -652,7 +652,7 @@ void yaoEvalFeedOblivInputs(ProtocolDesc* pd
 bool yaoGenrRevealOblivBits(ProtocolDesc* pd,
     widest_t* dest,const OblivBit* o,size_t n,int party)
 {
-  int i,bc=(n+7)/8;
+  size_t i,bc=(n+7)/8;
   widest_t rv=0, flipflags=0;
   YaoProtocolDesc *ypd = pd->extra;
   for(i=0;i<n;++i) if(o[i].unknown)
@@ -669,7 +669,7 @@ bool yaoGenrRevealOblivBits(ProtocolDesc* pd,
 bool yaoEvalRevealOblivBits(ProtocolDesc* pd,
     widest_t* dest,const OblivBit* o,size_t n,int party)
 {
-  int i,bc=(n+7)/8;
+  size_t i,bc=(n+7)/8;
   widest_t rv=0, flipflags=0;
   YaoProtocolDesc* ypd = pd->extra;
   for(i=0;i<n;++i) if(o[i].unknown)
@@ -1865,7 +1865,7 @@ void feedOblivInputs(OblivInputs* spec, size_t count, int party)
     void feedObliv##tname##Array(__obliv_c__##ot dest[],const t src[],size_t n,\
                              int party)\
     {\
-      int i,p = protoCurrentParty(currentProto);\
+      size_t i,p = protoCurrentParty(currentProto);\
       OblivInputs *specs = malloc(n*sizeof*specs);\
       for(i=0;i<n;++i) setupObliv##tname(specs+i,dest+i,p==party?src[i]:0);\
       feedOblivInputs(specs,n,party);\

--- a/src/ext/oblivc/obliv_types.h
+++ b/src/ext/oblivc/obliv_types.h
@@ -67,6 +67,7 @@ struct ProtocolDesc {
 
   //helper function to copy extra field
   void (*copyextra)(ProtocolDesc*,ProtocolDesc*);
+  void (*cleanextra)(ProtocolDesc*);
 };
 
 #define OC_DYN_EXTRA_FUN(fname,Type1,Type2,type2Id)    \

--- a/src/ext/oblivc/obliv_types.h
+++ b/src/ext/oblivc/obliv_types.h
@@ -64,6 +64,9 @@ struct ProtocolDesc {
 
   void* extra;  // protocol-specific information
                 // First field should be char protoType
+
+  //helper function to copy extra field
+  void (*copyextra)(ProtocolDesc*,ProtocolDesc*);
 };
 
 #define OC_DYN_EXTRA_FUN(fname,Type1,Type2,type2Id)    \

--- a/src/ext/oblivc/obliv_types_internal.h
+++ b/src/ext/oblivc/obliv_types_internal.h
@@ -38,8 +38,8 @@ static inline bool curBit (OIBitSrc* s) { return s->oi[s->i].src & (1LL<<s->j); 
 static inline OblivBit* curDestBit(OIBitSrc* s) { return s->oi[s->i].dest+s->j; }
 static inline void nextBit(OIBitSrc* s) 
   { if(++(s->j)>=s->oi[s->i].size) { s->j=0; ++(s->i); } }
-static inline int bitCount(OIBitSrc* s) 
-{ int res=0,i;
+static inline size_t bitCount(OIBitSrc* s) 
+{ size_t res=0,i;
   for(i=0;i<s->n;++i) res+=s->oi[i].size;
   return res;
 }

--- a/src/ext/oblivc/obliv_types_internal.h
+++ b/src/ext/oblivc/obliv_types_internal.h
@@ -30,7 +30,7 @@ typedef struct OblivBit {
 
 // Dev warning: name clashes likely. Fix when it becomes a problem
 // Java-style iterator over bits in OblivInput array, assumes all sizes > 0
-typedef struct { int i,j; OblivInputs* oi; size_t n; } OIBitSrc;
+typedef struct { size_t i,j; OblivInputs* oi; size_t n; } OIBitSrc;
 static inline OIBitSrc oiBitSrc(OblivInputs* oi,size_t n) 
   { return (OIBitSrc){.i = 0, .j = 0, .oi = oi, .n = n}; }
 static inline bool hasBit (OIBitSrc* s) { return s->i<s->n; }


### PR DESCRIPTION
I've changed a couple of things here:

Many int32s enlarged so that we can handle large arrays of obliv data
Network profiling turned on permanently
Added a generic interface for protocol splitting, plus implementations for Yao (sans OT)

I haven't yet finished OT splitting, so feeding inputs doesn't work on threads that have been split from the original. I'm submitting a PR anyway because it will likely be a few weeks before I have time, and I know a couple of projects would find the existing changes useful.