### PR TITLE
Floram support

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -105,10 +105,10 @@ $(OCAMLBUILD_TARGETS): ocamlbuild
 	@:
 
 # ------ these lines were added for obliv-C runtime -----------
-ifeq ($(RELEASE),1)
-  CFLAGS=-O3
-else
+ifeq ($(DEBUG),1)
   CFLAGS=-g
+else
+  CFLAGS=-O3
 endif
 DEPENDDIR = $(OBJDIR)/depends
 OCSRCDIR = src/ext/oblivc

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Obliv-C is a simple GCC wrapper that makes it easy to embed secure computation p
   * For Ubuntu: `sudo apt-get install ocaml libgcrypt20-dev ocaml-findlib`.
   * For Fedora: `sudo dnf install glibc-devel.i686 ocaml ocaml-ocamldoc ocaml-findlib ocaml-findlib-devel libgcrypt libgcrypt-devel perl-ExtUtils-MakeMaker perl-Data-Dumper`
 
-2. Git-clone this repository, and do a `./configure && make RELEASE=1`. 
+2. Git-clone this repository, and do a `./configure && make`. 
 
 3. Start using it! The compiler is a GCC wrapper script found in `bin/oblivcc`. Example codes are in `test/oblivc`. A language tutorial is found [here](http://goo.gl/TXzxD0).
 

--- a/src/ext/oblivc/obliv.h
+++ b/src/ext/oblivc/obliv.h
@@ -10,7 +10,7 @@
 //   keep it a valid obliv-C file after preprocessing. So e.g., no magic
 //   conversion from obliv int to OblivBits* inside inline functions.
 //   In fact, user code should never be aware of OblivBits type.
-void transportEnableProfiling(bool);
+void setTransportProfiling(bool);
 void protocolUseStdio(ProtocolDesc*);
 void protocolUseTcp2P(ProtocolDesc* pd,int sock,bool isClient);
 void protocolUseTcp2PKeepAlive(ProtocolDesc* pd,int sock,bool isClient);

--- a/src/ext/oblivc/obliv.h
+++ b/src/ext/oblivc/obliv.h
@@ -10,6 +10,7 @@
 //   keep it a valid obliv-C file after preprocessing. So e.g., no magic
 //   conversion from obliv int to OblivBits* inside inline functions.
 //   In fact, user code should never be aware of OblivBits type.
+void transportEnableProfiling(bool);
 void protocolUseStdio(ProtocolDesc*);
 void protocolUseTcp2P(ProtocolDesc* pd,int sock,bool isClient);
 void protocolUseTcp2PKeepAlive(ProtocolDesc* pd,int sock,bool isClient);
@@ -32,5 +33,6 @@ bool execNpProtocol_Bcast1(ProtocolDesc* pd, protocol_run start, void* arg);
 void execNnobProtocol(ProtocolDesc* pd, protocol_run start, void* arg, int numOTs, bool useAltOTExt);
 
 size_t tcp2PBytesSent(ProtocolDesc* pd);
+size_t tcp2PFlushCount(ProtocolDesc* pd);
 
 #endif // OBLIV_H

--- a/src/ext/oblivc/obliv.h
+++ b/src/ext/oblivc/obliv.h
@@ -10,7 +10,6 @@
 //   keep it a valid obliv-C file after preprocessing. So e.g., no magic
 //   conversion from obliv int to OblivBits* inside inline functions.
 //   In fact, user code should never be aware of OblivBits type.
-void setTransportProfiling(bool);
 void protocolUseStdio(ProtocolDesc*);
 void protocolUseTcp2P(ProtocolDesc* pd,int sock,bool isClient);
 void protocolUseTcp2PProfiled(ProtocolDesc* pd,int sock,bool isClient);

--- a/src/ext/oblivc/obliv.h
+++ b/src/ext/oblivc/obliv.h
@@ -13,11 +13,14 @@
 void setTransportProfiling(bool);
 void protocolUseStdio(ProtocolDesc*);
 void protocolUseTcp2P(ProtocolDesc* pd,int sock,bool isClient);
+void protocolUseTcp2PProfiled(ProtocolDesc* pd,int sock,bool isClient);
 void protocolUseTcp2PKeepAlive(ProtocolDesc* pd,int sock,bool isClient);
 void protocolAddSizeCheck(ProtocolDesc* pd);
 // The old sockCount parameter (was the last param) is no longer used.
 int protocolConnectTcp2P(ProtocolDesc* pd,const char* server,const char* port);
 int protocolAcceptTcp2P(ProtocolDesc* pd,const char* port);
+int protocolConnectTcp2PProfiled(ProtocolDesc* pd,const char* server,const char* port);
+int protocolAcceptTcp2PProfiled(ProtocolDesc* pd,const char* port);
 void cleanupProtocol(ProtocolDesc*);
 
 void setCurrentParty(ProtocolDesc* pd, int party);

--- a/src/ext/oblivc/obliv_bits.c
+++ b/src/ext/oblivc/obliv_bits.c
@@ -625,12 +625,12 @@ void yaoGenrFeedOblivInputs(ProtocolDesc* pd
     o->yao.inverted = false; o->unknown = true;
     yaoKeyCopy(o->yao.w,w0);
   }else 
-  { int bc = bitCount(&it);
+  { size_t bc = bitCount(&it);
     // limit memory usage
-    int batch = (bc<YAO_FEED_MAX_BATCH?bc:YAO_FEED_MAX_BATCH);
+    size_t batch = (bc<YAO_FEED_MAX_BATCH?bc:YAO_FEED_MAX_BATCH);
     char *buf0 = malloc(batch*YAO_KEY_BYTES),
          *buf1 = malloc(batch*YAO_KEY_BYTES);
-    int bp=0;
+    size_t bp=0;
     for(;hasBit(&it);nextBit(&it))
     { 
       OblivBit* o = curDestBit(&it);
@@ -659,13 +659,13 @@ void yaoEvalFeedOblivInputs(ProtocolDesc* pd
     o->unknown = true;
     ypd->icount++;
   }else 
-  { int bc = bitCount(&it);
+  { size_t bc = bitCount(&it);
     // limit memory usage
-    int batch = (bc<YAO_FEED_MAX_BATCH?bc:YAO_FEED_MAX_BATCH);
+    size_t batch = (bc<YAO_FEED_MAX_BATCH?bc:YAO_FEED_MAX_BATCH);
     char *buf = malloc(batch*YAO_KEY_BYTES),
          **dest = malloc(batch*sizeof(char*));
     bool *sel = malloc(batch*sizeof(bool));
-    int bp=0,i;
+    size_t bp=0,i;
     for(;hasBit(&it);nextBit(&it))
     { OblivBit* o = curDestBit(&it);
       dest[bp]=o->yao.w;
@@ -690,7 +690,7 @@ void yaoEvalFeedOblivInputs(ProtocolDesc* pd
 bool yaoGenrRevealOblivBits(ProtocolDesc* pd,
     widest_t* dest,const OblivBit* o,size_t n,int party)
 {
-  int i,bc=(n+7)/8;
+  size_t i,bc=(n+7)/8;
   widest_t rv=0, flipflags=0;
   YaoProtocolDesc *ypd = pd->extra;
   for(i=0;i<n;++i) if(o[i].unknown)
@@ -707,7 +707,7 @@ bool yaoGenrRevealOblivBits(ProtocolDesc* pd,
 bool yaoEvalRevealOblivBits(ProtocolDesc* pd,
     widest_t* dest,const OblivBit* o,size_t n,int party)
 {
-  int i,bc=(n+7)/8;
+  size_t i,bc=(n+7)/8;
   widest_t rv=0, flipflags=0;
   YaoProtocolDesc* ypd = pd->extra;
   for(i=0;i<n;++i) if(o[i].unknown)
@@ -1862,7 +1862,7 @@ void feedOblivInputs(OblivInputs* spec, size_t count, int party)
     void feedObliv##tname##Array(__obliv_c__##ot dest[],const t src[],size_t n,\
                              int party)\
     {\
-      int i,p = protoCurrentParty(currentProto);\
+      size_t i,p = protoCurrentParty(currentProto);\
       OblivInputs *specs = malloc(n*sizeof*specs);\
       for(i=0;i<n;++i) setupObliv##tname(specs+i,dest+i,p==party?src[i]:0);\
       feedOblivInputs(specs,n,party);\

--- a/src/ext/oblivc/obliv_bits.c
+++ b/src/ext/oblivc/obliv_bits.c
@@ -364,7 +364,14 @@ void protocolAddSizeCheck(ProtocolDesc* pd)
   t->cb.recv=sizeCheckRecv;
   t->cb.cleanup=sizeCheckCleanup;
 }
-// ---------------------------------------------------------------------------
+
+// --------------------------- Protocols -----------------------------------
+
+int ocCurrentParty() { return currentProto->currentParty(currentProto); }
+int ocCurrentPartyDefault(ProtocolDesc* pd) { return pd->thisParty; }
+
+ProtocolDesc* ocCurrentProto() { return currentProto; }
+void ocSetCurrentProto(ProtocolDesc* pd) { currentProto=pd; }
 
 void cleanupProtocol(ProtocolDesc* pd)
   { pd->trans->cleanup(pd->trans); }
@@ -372,16 +379,7 @@ void cleanupProtocol(ProtocolDesc* pd)
 void setCurrentParty(ProtocolDesc* pd, int party)
   { pd->thisParty=party; }
 
-void __obliv_c__assignBitKnown(OblivBit* dest, bool value)
-  { dest->knownValue = value; dest->unknown=false; }
-
-void __obliv_c__copyBit(OblivBit* dest,const OblivBit* src)
-  { if(dest!=src) *dest=*src; }
-
-bool __obliv_c__bitIsKnown(bool* v,const OblivBit* bit)
-{ if(known(bit)) *v=bit->knownValue;
-  return known(bit);
-}
+// --------------------------- Debug Protocol ----------------------------
 
 // TODO all sorts of identical parameter optimizations
 // Implementation note: remember that all these pointers may alias each other
@@ -414,6 +412,66 @@ void dbgProtoSetBitNot(ProtocolDesc* pd,OblivBit* dest,const OblivBit* a)
 }
 void dbgProtoFlipBit(ProtocolDesc* pd,OblivBit* dest) 
   { dest->knownValue = !dest->knownValue; }
+
+static void dbgFeedOblivBool(OblivBit* dest,int party,bool a)
+{ 
+  int curparty = ocCurrentParty();
+  
+  dest->unknown=true;
+  if(party==1) { if(curparty==1) dest->knownValue=a; }
+  else if(party==2 && curparty == 1) 
+    orecv(currentProto,2,&dest->knownValue,sizeof(bool));
+  else if(party==2 && curparty == 2) osend(currentProto,1,&a,sizeof(bool));
+  else fprintf(stderr,"Error: This is a 2 party protocol\n");
+}
+
+void dbgProtoFeedOblivInputs(ProtocolDesc* pd,
+    OblivInputs* spec,size_t count,int party)
+{ while(count--)
+  { int i;
+    widest_t v = spec->src;
+    for(i=0;i<spec->size;++i) 
+    { dbgFeedOblivBool(spec->dest+i,party,v&1);
+      v>>=1;
+    }
+    spec++;
+  }
+}
+
+bool dbgProtoRevealOblivBits
+  (ProtocolDesc* pd,widest_t* dest,const OblivBit* src,size_t size,int party)
+{ widest_t rv=0;
+  if(currentProto->thisParty==1)
+  { src+=size;
+    while(size-->0) rv = (rv<<1)+!!(--src)->knownValue;
+    if(party==0 || party==2) osend(pd,2,&rv,sizeof(rv));
+    if(party==2) return false;
+    else { *dest=rv; return true; }
+  }else // assuming thisParty==2
+  { if(party==0 || party==2) { orecv(pd,1,dest,sizeof(*dest)); return true; }
+    else return false;
+  }
+}
+
+bool ocInDebugProto(void) { return ocCurrentProto()->extra==NULL; }
+
+void execDebugProtocol(ProtocolDesc* pd, protocol_run start, void* arg)
+{
+  pd->currentParty = ocCurrentPartyDefault;
+  pd->error = 0;
+  pd->feedOblivInputs = dbgProtoFeedOblivInputs;
+  pd->revealOblivBits = dbgProtoRevealOblivBits;
+  pd->setBitAnd = dbgProtoSetBitAnd;
+  pd->setBitOr  = dbgProtoSetBitOr;
+  pd->setBitXor = dbgProtoSetBitXor;
+  pd->setBitNot = dbgProtoSetBitNot;
+  pd->flipBit   = dbgProtoFlipBit;
+  pd->partyCount= 2;
+  pd->extra = NULL;
+  currentProto = pd;
+  currentProto->debug.mulCount = currentProto->debug.xorCount = 0;
+  start(arg);
+}
 
 //-------------------- Yao Protocol (honest but curious) -------------
 
@@ -1151,6 +1209,9 @@ void yaoEHalfSwapGate(ProtocolDesc* pd,
   }
   free(x);
 }
+
+// --------------------------- NNOB protocol ---------------------------------
+
 /*void nnobAndGatesCount(ProtocolDesc* pd, protocol_run start, void* arg)*/
 /*{*/
   /*pd->currentParty = ocCurrentPartyDefault;*/
@@ -1289,6 +1350,19 @@ void execNnobProtocol(ProtocolDesc* pd, protocol_run start, void* arg, int numOT
 }
 #endif // ENABLE_NNOB
 
+// --------------------------- Obliv-c primitives --------------------------------
+
+void __obliv_c__assignBitKnown(OblivBit* dest, bool value)
+  { dest->knownValue = value; dest->unknown=false; }
+
+void __obliv_c__copyBit(OblivBit* dest,const OblivBit* src)
+  { if(dest!=src) *dest=*src; }
+
+bool __obliv_c__bitIsKnown(bool* v,const OblivBit* bit)
+{ if(known(bit)) *v=bit->knownValue;
+  return known(bit);
+}
+
 void __obliv_c__setBitAnd(OblivBit* dest,const OblivBit* a,const OblivBit* b)
 {
   if(known(a) || known(b))
@@ -1297,6 +1371,7 @@ void __obliv_c__setBitAnd(OblivBit* dest,const OblivBit* a,const OblivBit* b)
     else __obliv_c__assignBitKnown(dest,false);
   }else currentProto->setBitAnd(currentProto,dest,a,b);
 }
+
 void __obliv_c__setBitOr(OblivBit* dest,const OblivBit* a,const OblivBit* b)
 {
   if(known(a) || known(b))
@@ -1305,6 +1380,7 @@ void __obliv_c__setBitOr(OblivBit* dest,const OblivBit* a,const OblivBit* b)
     else __obliv_c__assignBitKnown(dest,true);
   }else currentProto->setBitOr(currentProto,dest,a,b);
 }
+
 void __obliv_c__setBitXor(OblivBit* dest,const OblivBit* a,const OblivBit* b)
 {
   bool v;
@@ -1324,55 +1400,11 @@ void __obliv_c__flipBit(OblivBit* dest)
   else currentProto->flipBit(currentProto,dest); 
 }
 
-static void dbgFeedOblivBool(OblivBit* dest,int party,bool a)
-{ 
-  int curparty = ocCurrentParty();
-  
-  dest->unknown=true;
-  if(party==1) { if(curparty==1) dest->knownValue=a; }
-  else if(party==2 && curparty == 1) 
-    orecv(currentProto,2,&dest->knownValue,sizeof(bool));
-  else if(party==2 && curparty == 2) osend(currentProto,1,&a,sizeof(bool));
-  else fprintf(stderr,"Error: This is a 2 party protocol\n");
-}
-  /*
-void __obliv_c__feedOblivBits(OblivBit* dest, int party
-                             ,const bool* src,size_t size)
-  { while(size--) __obliv_c__feedOblivBool(dest++,party,*(src++)); }
-*/
-
 void __obliv_c__setupOblivBits(OblivInputs* spec,OblivBit*  dest
                                      ,widest_t v,size_t size)
 { spec->dest=dest;
   spec->src=v;
   spec->size=size;
-}
-void dbgProtoFeedOblivInputs(ProtocolDesc* pd,
-    OblivInputs* spec,size_t count,int party)
-{ while(count--)
-  { int i;
-    widest_t v = spec->src;
-    for(i=0;i<spec->size;++i) 
-    { dbgFeedOblivBool(spec->dest+i,party,v&1);
-      v>>=1;
-    }
-    spec++;
-  }
-}
-
-bool dbgProtoRevealOblivBits
-  (ProtocolDesc* pd,widest_t* dest,const OblivBit* src,size_t size,int party)
-{ widest_t rv=0;
-  if(currentProto->thisParty==1)
-  { src+=size;
-    while(size-->0) rv = (rv<<1)+!!(--src)->knownValue;
-    if(party==0 || party==2) osend(pd,2,&rv,sizeof(rv));
-    if(party==2) return false;
-    else { *dest=rv; return true; }
-  }else // assuming thisParty==2
-  { if(party==0 || party==2) { orecv(pd,1,dest,sizeof(*dest)); return true; }
-    else return false;
-  }
 }
 
 static void broadcastBits(int source,void* p,size_t n)
@@ -1383,35 +1415,9 @@ static void broadcastBits(int source,void* p,size_t n)
       osend(currentProto,i,p,n);
 }
 
-void execDebugProtocol(ProtocolDesc* pd, protocol_run start, void* arg)
-{
-  pd->currentParty = ocCurrentPartyDefault;
-  pd->error = 0;
-  pd->feedOblivInputs = dbgProtoFeedOblivInputs;
-  pd->revealOblivBits = dbgProtoRevealOblivBits;
-  pd->setBitAnd = dbgProtoSetBitAnd;
-  pd->setBitOr  = dbgProtoSetBitOr;
-  pd->setBitXor = dbgProtoSetBitXor;
-  pd->setBitNot = dbgProtoSetBitNot;
-  pd->flipBit   = dbgProtoFlipBit;
-  pd->partyCount= 2;
-  pd->extra = NULL;
-  currentProto = pd;
-  currentProto->debug.mulCount = currentProto->debug.xorCount = 0;
-  start(arg);
-}
-
 bool __obliv_c__revealOblivBits (widest_t* dest, const OblivBit* src
                                 ,size_t size, int party)
   { return currentProto->revealOblivBits(currentProto,dest,src,size,party); }
-
-int ocCurrentParty() { return currentProto->currentParty(currentProto); }
-int ocCurrentPartyDefault(ProtocolDesc* pd) { return pd->thisParty; }
-
-ProtocolDesc* ocCurrentProto() { return currentProto; }
-void ocSetCurrentProto(ProtocolDesc* pd) { currentProto=pd; }
-
-bool ocInDebugProto(void) { return ocCurrentProto()->extra==NULL; }
 
 void __obliv_c__setSignedKnown
   (void* vdest, size_t size, long long signed value)

--- a/src/ext/oblivc/obliv_bits.c
+++ b/src/ext/oblivc/obliv_bits.c
@@ -415,7 +415,6 @@ void ocSplitProto(ProtocolDesc* pdout, ProtocolDesc * pdin)
     .extra = NULL
   };
   if (pdout->splitextra != NULL && pdin->extra != NULL) pdout->splitextra(pdout, pdin);
-  oflush(pdin); oflush(pdout);
 }
 
 void ocCleanupProto(ProtocolDesc* pd)
@@ -1032,6 +1031,7 @@ void splitYaoProtocolExtra(ProtocolDesc* pdout, ProtocolDesc * pdin) {
     ypdout->recver = honestOTExtRecverAbstract(honestOTExtRecverNew(pdout,1));
   }
   ypdout->gcount = ypdout->gcount_offset;
+  oflush(pdin); oflush(pdout);
 }
 
 /* execYaoProtocol is divided into 2 parts which are reused by other

--- a/src/ext/oblivc/obliv_bits.h
+++ b/src/ext/oblivc/obliv_bits.h
@@ -10,7 +10,10 @@
 // import common types
 #include<obliv_types_internal.h>
 
+ProtocolDesc* ocCurrentProto(void);
 void ocSetCurrentProto(ProtocolDesc* pd);
+void ocSplitProto(ProtocolDesc*, ProtocolDesc*);
+void ocCleanupProto(ProtocolDesc*);
 
 #define __bitsize(type) (8*sizeof(type))
 

--- a/src/ext/oblivc/obliv_common.h
+++ b/src/ext/oblivc/obliv_common.h
@@ -2,6 +2,7 @@
 #define OBLIV_COMMON_H
 
 #include<obliv_types.h>
+#include<obliv_bits.h>
 //#include<stdio.h>
 //FILE* transGetFile(ProtocolTransport* t); // Debugging API
 
@@ -10,8 +11,6 @@
 // Java-style redundant "say the type twice" practice
 #define CAST(p) ((void*)p)
 
-struct ProtocolDesc* ocCurrentProto(void);
-int ocCurrentParty(void);
 static inline int protoCurrentParty(ProtocolDesc* pd)
     { return pd->currentParty(pd); }
 static inline char ocCurrentProtoType()
@@ -24,10 +23,15 @@ static inline int transSend(ProtocolTransport* t,int d,const void* p,size_t n)
   { return t->send(t,d,p,n); }
 static inline int transRecv(ProtocolTransport* t,int s,void* p,size_t n)
   { return t->recv(t,s,p,n); }
+static inline int transFlush(ProtocolTransport* t)
+  { if (t->flush) return t->flush(t); else return 0; }
 static inline int osend(ProtocolDesc* pd,int d,const void* p,size_t n)
   { return transSend(pd->trans,d,p,n); }
 static inline int orecv(ProtocolDesc* pd,int s,void* p,size_t n)
   { return transRecv(pd->trans,s,p,n); }
+static inline int oflush(ProtocolDesc* pd)
+  { return transFlush(pd->trans); }
+
 
 // Maybe these 5 lines should move to bcrandom.h
 #define DHCurveName "secp256r1"

--- a/src/ext/oblivc/obliv_types.h
+++ b/src/ext/oblivc/obliv_types.h
@@ -64,6 +64,11 @@ struct ProtocolDesc {
 
   void* extra;  // protocol-specific information
                 // First field should be char protoType
+
+  // helper functions to split extra protocol info for new threads, and clean up
+  // split protocols when they're done
+  void (*splitextra)(ProtocolDesc*,ProtocolDesc*);
+  void (*cleanextra)(ProtocolDesc*);
 };
 
 #define OC_DYN_EXTRA_FUN(fname,Type1,Type2,type2Id)    \
@@ -105,8 +110,9 @@ typedef OTrecver COTrecver; // Strong typedef would have been nice
 typedef struct YaoProtocolDesc {
   char protoType;
   yao_key_t R,I; // LSB of R needs to be 1
-  uint64_t gcount;
-  unsigned icount, ocount;
+  uint64_t gcount, gcount_offset;
+  uint64_t icount, ocount;
+  bool ownOT;
   void (*nonFreeGate)(struct ProtocolDesc*,OblivBit*,char,
       const OblivBit*,const OblivBit*);
   union { OTsender sender; OTrecver recver; };
@@ -126,6 +132,7 @@ struct ProtocolTransport {
   ProtocolTransport* (*split)(ProtocolTransport*);
   int (*send)(ProtocolTransport*,int,const void*,size_t);
   int (*recv)(ProtocolTransport*,int,      void*,size_t);
+  int (*flush)(ProtocolTransport*);
   void (*cleanup)(ProtocolTransport*);
 };
 

--- a/src/ext/oblivc/obliv_types_internal.h
+++ b/src/ext/oblivc/obliv_types_internal.h
@@ -30,7 +30,7 @@ typedef struct OblivBit {
 
 // Dev warning: name clashes likely. Fix when it becomes a problem
 // Java-style iterator over bits in OblivInput array, assumes all sizes > 0
-typedef struct { int i,j; OblivInputs* oi; size_t n; } OIBitSrc;
+typedef struct { size_t i,j; OblivInputs* oi; size_t n; } OIBitSrc;
 static inline OIBitSrc oiBitSrc(OblivInputs* oi,size_t n) 
   { return (OIBitSrc){.i = 0, .j = 0, .oi = oi, .n = n}; }
 static inline bool hasBit (OIBitSrc* s) { return s->i<s->n; }
@@ -38,8 +38,8 @@ static inline bool curBit (OIBitSrc* s) { return s->oi[s->i].src & (1LL<<s->j); 
 static inline OblivBit* curDestBit(OIBitSrc* s) { return s->oi[s->i].dest+s->j; }
 static inline void nextBit(OIBitSrc* s) 
   { if(++(s->j)>=s->oi[s->i].size) { s->j=0; ++(s->i); } }
-static inline int bitCount(OIBitSrc* s) 
-{ int res=0,i;
+static inline size_t bitCount(OIBitSrc* s) 
+{ size_t res=0,i;
   for(i=0;i<s->n;++i) res+=s->oi[i].size;
   return res;
 }

--- a/test/oblivc/README.txt
+++ b/test/oblivc/README.txt
@@ -1,11 +1,12 @@
 Folders:
-  common/   - Utility files used by test cases
-  editdist/ - Computes Levenstein distance between strings
-  hamming/  - Computes hamming distance between strings
-  million/  - Compares two int to see which is greater
-  aes/      - Computes AES of a single block (with key expansion)
-  ottest/   - Various microbenchmarks for OT protocols
-  psi/      - Private set intersection between sets of random ints
+  common/     - Utility files used by test cases
+  editdist/   - Computes Levenstein distance between strings
+  hamming/    - Computes hamming distance between strings
+  million/    - Compares two int to see which is greater
+  aes/        - Computes AES of a single block (with key expansion)
+  ottest/     - Various microbenchmarks for OT protocols
+  psi/        - Private set intersection between sets of random ints
+  protosplit/ - Tests for multithreading and protocol splitting
 
 To run these tests (assuming the project has been already built), you should
 just go to the folder and run the respective Makefile. This should give you

--- a/test/oblivc/protosplit/Makefile
+++ b/test/oblivc/protosplit/Makefile
@@ -1,0 +1,18 @@
+CILPATH=../../../
+OBLIVCH=$(CILPATH)/src/ext/oblivc
+OBLIVCC= $(CILPATH)/bin/oblivcc
+OBLIVCA= $(CILPATH)/_build/libobliv.a
+REMOTE_HOST=localhost
+CFLAGS=-DREMOTE_HOST=$(REMOTE_HOST) -O3  -fopenmp -I .
+
+./a.out: protosplittest.oo protosplittest.o main.o ../common/util.o
+	$(OBLIVCC) $(OBLIVCA) $^ -lm -lgomp
+
+%.o: %.c
+	gcc -c $(CFLAGS) $*.c -o $*.o -I $(OBLIVCH)
+
+%.oo: %.oc
+	$(OBLIVCC) -c $(CFLAGS) $*.oc -o $*.oo
+
+clean:
+	rm -f a.out

--- a/test/oblivc/protosplit/main.c
+++ b/test/oblivc/protosplit/main.c
@@ -1,0 +1,35 @@
+#include<stdio.h>
+#include<time.h>
+
+#include"../common/util.h"
+#include"protosplittest.h"
+
+double lap;
+
+int main(int argc,char* argv[])
+{ 
+  ProtocolDesc pd;
+
+  if(argc<3)
+  {
+    if(argc<2) fprintf(stderr,"Port number missing\n");
+    else if(argc<3) fprintf(stderr,"Party missing\n");
+    else fprintf(stderr,"string missing\n");
+    fprintf(stderr,"Usage: %s <port> <--|remote_host>\n",argv[0]);
+    return 1;
+  }
+
+  const char* remote_host = (strcmp(argv[2],"--")==0?NULL:argv[2]);
+  int i, party = (!remote_host?1:2);
+
+  //protocolUseStdio(&pd);
+  ocTestUtilTcpOrDie(&pd,remote_host,argv[1]);
+  setCurrentParty(&pd,party);
+
+  lap = wallClock();
+  execYaoProtocol(&pd,goprotosplit,NULL);
+  fprintf(stderr,"Total time: %lf s\n",wallClock()-lap);
+  cleanupProtocol(&pd);
+  fprintf(stderr,"\n");
+  return 0;
+}

--- a/test/oblivc/protosplit/protosplittest.c
+++ b/test/oblivc/protosplit/protosplittest.c
@@ -1,0 +1,22 @@
+#include "protosplittest.h"
+
+void parallelize(split_fn fn, void * output1, void * output2, void * output3, uint32_t * input, int leneach, void * pd1, void* pd2) {
+	#pragma omp parallel num_threads(3)
+	{
+		//OpenMP seems to get along with obliv-c just fine, so long as obliv-c only uses the master thread.
+		#pragma omp master
+		{
+			fn(output1, input, leneach, NULL);
+		}
+		
+
+		#pragma omp single
+		{
+			#pragma omp task
+			fn(output2, &input[leneach], leneach, pd1);
+
+			#pragma omp task
+			fn(output3, &input[2*leneach], leneach, pd2);
+		}
+	}
+}

--- a/test/oblivc/protosplit/protosplittest.h
+++ b/test/oblivc/protosplit/protosplittest.h
@@ -1,0 +1,10 @@
+#include <obliv.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#define ELCT 2000
+
+typedef void (* split_fn)(void *, uint32_t *, int, void *);
+
+void parallelize(split_fn fn, void * output1, void * output2, void * output3, uint32_t * input, int leneach, void * pd1, void* pd2);
+void goprotosplit(void* vargs);

--- a/test/oblivc/protosplit/protosplittest.oc
+++ b/test/oblivc/protosplit/protosplittest.oc
@@ -1,0 +1,35 @@
+#include <obliv.oh>
+#include "protosplittest.h"
+
+void reducelist(obliv uint32_t * output, uint32_t * inputs, int len, ProtocolDesc * pd) {
+	if (pd != NULL) ocSetCurrentProto(pd);
+
+	for (size_t ii = 0; ii < len; ii ++) {
+		*output += feedOblivInt(inputs[ii], ii%2 + 1);
+	}
+
+	// we want to flush if our protocol is done and other threads are waiting on us
+	// in this case, it's not strictly necessary, but it's a good habit.
+	if (pd != NULL) oflush(pd);
+}
+
+void goprotosplit(void* vargs) {
+	obliv uint32_t output1, output2, output3;
+
+	uint32_t * inputs = malloc(ELCT * 3 * sizeof(uint32_t));
+	for (size_t ii = 0; ii < ELCT*3; ii++) inputs[ii] = ii+1;
+
+	ProtocolDesc pd1;
+	ocSplitProto(&pd1, ocCurrentProto());
+	ProtocolDesc pd2;
+	ocSplitProto(&pd2, &pd1);
+	parallelize(reducelist, &output1, &output2, &output3, inputs, ELCT, &pd1, &pd2);
+	ocCleanupProto(&pd2);
+	ocCleanupProto(&pd1);
+
+	output1 += output2 + output3;
+	uint32_t result;
+	revealOblivInt(&result, output1, 0);
+	printf("Result: %u, Expected: %u\n", result, (ELCT*3+1)*(ELCT*3)/2);
+	free(inputs);
+}


### PR DESCRIPTION
Included here: fixes for integer overflows that can occur in large/long-running computations; a slight modification to the makefile behavior (compiling in the old way will still produce the same result); fallback code plus consolidation (as requested) for the ocShare system in copy.c; a new, profiled TCP transport selectable at runtime without recompiling obliv-c; protocol splitting for Yao (with a generic API).