### PR TITLE
Fixed stdio transports, which were broken by recent updates.

### DIFF
--- a/src/ext/oblivc/obliv_bits.c
+++ b/src/ext/oblivc/obliv_bits.c
@@ -402,7 +402,12 @@ void setCurrentParty(ProtocolDesc* pd, int party)
 ProtocolDesc* ocCurrentProto() { return currentProto; }
 void ocSetCurrentProto(ProtocolDesc* pd) { currentProto=pd; }
 
-bool ocCanSplitProto(ProtocolDesc * pdin) { return (pdin->trans->split != NULL && pdin->splitextra != NULL && pdin->extra != NULL); }
+bool ocCanSplitProto(ProtocolDesc * pdin)
+{
+  return pdin->trans->split != NULL
+        && pdin->splitextra != NULL
+        && pdin->extra != NULL;
+}
 
 bool ocSplitProto(ProtocolDesc* pdout, ProtocolDesc * pdin)
 { if (!ocCanSplitProto(pdin)) return false;

--- a/src/ext/oblivc/obliv_bits.c
+++ b/src/ext/oblivc/obliv_bits.c
@@ -402,26 +402,32 @@ void setCurrentParty(ProtocolDesc* pd, int party)
 ProtocolDesc* ocCurrentProto() { return currentProto; }
 void ocSetCurrentProto(ProtocolDesc* pd) { currentProto=pd; }
 
-void ocSplitProto(ProtocolDesc* pdout, ProtocolDesc * pdin)
-{
-  *pdout = (struct ProtocolDesc) {
-    .error = pdin->error,
-    .partyCount = pdin->error,
-    .currentParty = pdin->currentParty,
-    .feedOblivInputs = pdin->feedOblivInputs,
-    .revealOblivBits = pdin->revealOblivBits,
-    .setBitAnd = pdin->setBitAnd,
-    .setBitOr = pdin->setBitOr,
-    .setBitXor = pdin->setBitXor,
-    .setBitNot = pdin->setBitNot,
-    .flipBit = pdin->flipBit,
-    .thisParty = pdin->thisParty,
-    .trans = pdin->trans->split(pdin->trans),
-    .splitextra = pdin->splitextra,
-    .cleanextra = pdin->cleanextra,
-    .extra = NULL
-  };
-  if (pdout->splitextra != NULL && pdin->extra != NULL) pdout->splitextra(pdout, pdin);
+bool ocCanSplitProto(ProtocolDesc * pdin) { return (pdin->trans->split != NULL && pdin->splitextra != NULL && pdin->extra != NULL); }
+
+bool ocSplitProto(ProtocolDesc* pdout, ProtocolDesc * pdin)
+{ if (!ocCanSplitProto(pdin)) return false;
+  else
+  {
+    *pdout = (struct ProtocolDesc) {
+      .error = pdin->error,
+      .partyCount = pdin->error,
+      .currentParty = pdin->currentParty,
+      .feedOblivInputs = pdin->feedOblivInputs,
+      .revealOblivBits = pdin->revealOblivBits,
+      .setBitAnd = pdin->setBitAnd,
+      .setBitOr = pdin->setBitOr,
+      .setBitXor = pdin->setBitXor,
+      .setBitNot = pdin->setBitNot,
+      .flipBit = pdin->flipBit,
+      .thisParty = pdin->thisParty,
+      .trans = pdin->trans->split(pdin->trans),
+      .splitextra = pdin->splitextra,
+      .cleanextra = pdin->cleanextra,
+      .extra = NULL
+    };
+    pdout->splitextra(pdout, pdin);
+    return true;
+  }
 }
 
 void ocCleanupProto(ProtocolDesc* pd)

--- a/src/ext/oblivc/obliv_bits.h
+++ b/src/ext/oblivc/obliv_bits.h
@@ -12,7 +12,8 @@
 
 ProtocolDesc* ocCurrentProto(void);
 void ocSetCurrentProto(ProtocolDesc* pd);
-void ocSplitProto(ProtocolDesc*, ProtocolDesc*);
+bool ocCanSplitProto(ProtocolDesc*);
+bool ocSplitProto(ProtocolDesc*, ProtocolDesc*);
 void ocCleanupProto(ProtocolDesc*);
 
 #define __bitsize(type) (8*sizeof(type))

--- a/test/oblivc/million/README.txt
+++ b/test/oblivc/million/README.txt
@@ -1,9 +1,10 @@
-This test uses a tiny bash script `cycle` that oyu can find at https://github.com/samee/cmd
+This test uses a tiny bash script `cycle` that you can find at https://github.com/samee/cmd
 
 Simply compares two integers supplied by two parties on the command line. Doesn't even open a TCP socket, but instead uses stdio to run the protocol. For testing, we use a cyclic pipe:
 
 # compile using our GCC wrapper
 /path/to/oblivcc million.c million.oc -I .
+
 # run: party 1 provides input value 15, party 2 provides 10
 cycle './a.out 1 15 | ./a.out 2 10'
 # Result output should be -1, 0, or 1 depending 
@@ -12,3 +13,7 @@ cycle './a.out 1 15 | ./a.out 2 10'
 # to perform this over a network, say, over SSH:
 cycle './a.out 1 15 | ssh remotemachine.server.com:/remote/path/to/a.out 2 10'
 
+# alternatively, you can run the two parties without the cycle script:
+mkfifo temp_fifo
+./a.out 1 15 < temp_fifo | ./a.out 2 10 > temp_fifo
+rm temp_fifo

--- a/test/oblivc/protosplit/protosplittest.h
+++ b/test/oblivc/protosplit/protosplittest.h
@@ -1,6 +1,7 @@
 #include <obliv.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include <stdio.h>
 
 #define ELCT 2000
 

--- a/test/oblivc/protosplit/protosplittest.oc
+++ b/test/oblivc/protosplit/protosplittest.oc
@@ -1,4 +1,5 @@
 #include <obliv.oh>
+#include <obliv_common.h>
 #include "protosplittest.h"
 
 void reducelist(obliv uint32_t * output, uint32_t * inputs, int len, ProtocolDesc * pd) {


### PR DESCRIPTION
Also, I added alternative instructions to the readme for the millionaires' test.

It's worth noting that protocol splitting definitely doesn't work when using stdio. I'm not sure how it would be possible to rectify that. Perhaps it would be best simply to refuse to split (return false or something like that)?