### PR TITLE
Fix for bug introduced during refactoring, which caused efficiency regression.

### DIFF
--- a/src/ext/oblivc/obliv_bits.c
+++ b/src/ext/oblivc/obliv_bits.c
@@ -114,7 +114,7 @@ static int tcp2PRecv(ProtocolTransport* pt,int src,void* s,size_t n)
   if (tcpt->needFlush)
   {
     transFlush(pt);
-    tcpt->needFlush=true;
+    tcpt->needFlush=false;
   }
   while(n>n2)
   { 


### PR DESCRIPTION
My mistake. Flushes were happening much too frequently. Performance impact was noticeable (10-20%), but only for evaluator.