### PR TITLE
Added convenience functions for revealing and broadcasting arrays

### DIFF
--- a/src/ext/oblivc/obliv.oh
+++ b/src/ext/oblivc/obliv.oh
@@ -49,14 +49,35 @@ bool revealOblivInt(int* dest, obliv int src,int party);
 bool revealOblivShort(short* dest, obliv short src,int party);
 bool revealOblivLong(long* dest, obliv long src,int party);
 bool revealOblivLLong(long long* dest, obliv long long src,int party);
+
+bool  revealOblivBoolArray(bool dest[],  obliv bool src[],  size_t n,
+						   int party);
+bool  revealOblivCharArray(char dest[],  obliv char src[],  size_t n,
+						   int party);
+bool   revealOblivIntArray(int dest[],   obliv int src[],   size_t n,
+						   int party);
+bool revealOblivShortArray(short dest[], obliv short src[], size_t n,
+						   int party);
+bool  revealOblivLongArray(long dest[],  obliv long src[],  size_t n,
+						   int party);
+bool revealOblivLLongArray(long long dest[], obliv long long src[], size_t n,
+						   int party);
 #endif
 
-bool ocBroadcastBool(bool v,int source);
-char ocBroadcastChar(char v,int source);
-int ocBroadcastInt(int v,int source);
-short ocBroadcastShort(short v,int source);
-long ocBroadcastLong(long v,int source);
-long long ocBroadcastLLong(long long v,int source);
+bool ocBroadcastBool(bool v,int party);
+char ocBroadcastChar(char v,int party);
+int ocBroadcastInt(int v,int party);
+short ocBroadcastShort(short v,int party);
+long ocBroadcastLong(long v,int party);
+long long ocBroadcastLLong(long long v,int party);
+
+void  ocBroadcastBoolArray(bool dest[],   bool src[], size_t n, int party);
+void  ocBroadcastCharArray(char dest[],   char src[], size_t n, int party);
+void   ocBroadcastIntArray(int dest[],     int src[], size_t n, int party);
+void ocBroadcastShortArray(short dest[], short src[], size_t n, int party);
+void  ocBroadcastLongArray(long dest[],   long src[], size_t n, int party);
+void ocBroadcastLLongArray(long long dest[], long long src[], size_t n,
+							int party);
 
 uint64_t yaoGateCount(void);
 #endif

--- a/src/ext/oblivc/obliv_bits.c
+++ b/src/ext/oblivc/obliv_bits.c
@@ -1980,58 +1980,69 @@ feedOblivFun(long long,lLong,LLong)
 #undef feedOblivFun
 
 // TODO pass const values by ref later
-bool revealOblivBool(bool* dest,__obliv_c__bool src,int party)
+bool revealOblivBool(bool * dest, __obliv_c__bool src, int party)
 { widest_t wd;
-  if(__obliv_c__revealOblivBits(&wd,src.bits,1,party)) 
+  if(__obliv_c__revealOblivBits(&wd,src.bits,1,party))
     { *dest=(bool)wd; return true; }
   return false;
 }
-bool revealOblivChar(char* dest, __obliv_c__char src,int party)
-{ widest_t wd;
-  if(__obliv_c__revealOblivBits(&wd,src.bits,__bitsize(char),party)) 
-    { *dest=(char)wd; return true; }
-  return false;
-}
-bool revealOblivInt(int* dest, __obliv_c__int src,int party)
-{ widest_t wd;
-  if(__obliv_c__revealOblivBits(&wd,src.bits,__bitsize(int),party)) 
-    { *dest=(int)wd; return true; }
-  return false;
-}
-bool revealOblivShort(short* dest, __obliv_c__short src,int party)
-{ widest_t wd;
-  if(__obliv_c__revealOblivBits(&wd,src.bits,__bitsize(short),party)) 
-    { *dest=(short)wd; return true; }
-  return false;
-}
-bool revealOblivLong(long* dest, __obliv_c__long src,int party)
-{ widest_t wd;
-  if(__obliv_c__revealOblivBits(&wd,src.bits,__bitsize(long),party)) 
-    { *dest=(long)wd; return true; }
-  return false;
-}
-bool revealOblivLLong(long long* dest, __obliv_c__lLong src,int party)
-{ widest_t wd;
-  if(__obliv_c__revealOblivBits(&wd,src.bits,__bitsize(long long),party)) 
-    { *dest=(long long)wd; return true; }
-  return false;
+bool revealOblivBoolArray(bool *dest, const __obliv_c__bool * src,
+                              size_t n, int party)
+{ bool rv = true;
+  for (size_t ii = 0; ii < n; ii++)
+    { rv &= revealOblivBool(&dest[ii], src[ii], party); }
+  return rv;
 }
 
+#define revealOblivFun(t, ot, tname) \
+      bool revealObliv##tname(t * dest, __obliv_c__##ot src, int party) \
+      { widest_t wd; \
+        if(__obliv_c__revealOblivBits(&wd,src.bits,__bitsize(t),party)) \
+          { *dest=(t)wd; return true; } \
+        return false; \
+      } \
+      bool revealObliv##tname##Array(t *dest, const __obliv_c__##ot * src,\
+                                    size_t n, int party) \
+      { bool rv = true; \
+        for (size_t ii = 0; ii < n; ii++) \
+          { rv &= revealObliv##tname(&dest[ii], src[ii], party); } \
+        return rv; \
+      }
+
+revealOblivFun(char,char,Char);
+revealOblivFun(short,short,Short);
+revealOblivFun(int,int,Int);
+revealOblivFun(long,long,Long);
+revealOblivFun(long long,lLong,LLong);
+
+#undef revealOblivFun
+
 // TODO fix data width
-bool ocBroadcastBool(bool v,int source)
-{
-  char t = v;
-  broadcastBits(source,&t,1);
+bool ocBroadcastBool(bool v,int party)
+{ char t = v;
+  broadcastBits(party,&t,1);
   return t;
 }
+void ocBroadcastBoolArray(bool *dest, bool *src, size_t n, int party)
+{ for (size_t ii = 0; ii < n; ii ++)
+    { dest[ii] = ocBroadcastBool(src[ii], party); }
+}
+
 #define broadcastFun(t,tname)           \
-  t ocBroadcast##tname(t v, int source)   \
-  { broadcastBits(source,&v,sizeof(v)); \
-    return v;                           \
-  }
+      t ocBroadcast##tname(t v, int party)   \
+      { broadcastBits(party,&v,sizeof(t)); \
+        return v;                           \
+      } \
+      void ocBroadcast##tname##Array(t *dest, t *src, size_t n, int party) \
+      { if (ocCurrentParty() == party && dest != src) \
+          { memcpy(dest, src, n * sizeof(t)); } \
+        broadcastBits(party,dest,n * sizeof(t)); \
+      }
+
 broadcastFun(char,Char)
 broadcastFun(int,Int)
 broadcastFun(short,Short)
 broadcastFun(long,Long)
 broadcastFun(long long,LLong)
+
 #undef broadcastFun


### PR DESCRIPTION
To match similar functions for feeding, copying, and sharing/unsharing arrays. None of this is necessary, but I find it obviates a lot of common boilerplate code for me, and I believe the use case is fairly common for other people too.

 It occurs to me that we have two naming conventions here. Maybe in the future, we should choose one?