### PR TITLE
Resolve naming conflict with libgcrypt 1.8.0

### DIFF
--- a/src/ext/oblivc/ot.c
+++ b/src/ext/oblivc/ot.c
@@ -236,7 +236,7 @@ static void npotSend_roundRecvKey(NpotSender* s,NpotSenderState* q)
   { q->PK0 = dhRecv(s->pd,s->destParty); }
 
 // x,y,z are scratch
-static void gcry_mpi_point_copy(gcry_mpi_point_t w, gcry_mpi_point_t v,
+static void oblivc_mpi_point_copy(gcry_mpi_point_t w, gcry_mpi_point_t v,
       gcry_mpi_t x,gcry_mpi_t y,gcry_mpi_t z)
 {
   gcry_mpi_point_get(x,y,z,v);
@@ -354,7 +354,7 @@ static void npotRecv_roundSendKey(NpotRecver* r,NpotRecverState* q,int seli,
   gk = gcry_mpi_point_new(0);
   PK0 = gcry_mpi_point_new(0);
   gcry_mpi_ec_mul(gk,q->k,DHg,r->ctx);
-  gcry_mpi_point_copy(PK0,gk,r->scratchx,r->scratchy,r->scratchz);
+  oblivc_mpi_point_copy(PK0,gk,r->scratchx,r->scratchy,r->scratchz);
 
   if(seli==0) { i=0; p=&gk; }
   else { i=seli-1; p=&PK0; }


### PR DESCRIPTION
Feel free to change the name of the function, I just used the first thing that made sense to me. It might also be a good idea to rename `gcry_mpi_point_neg`. It's not defined by libgcrypt (yet), but it also uses its prefix.