### PR TITLE
Improvements to protocol splitting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -398,3 +398,5 @@
 /test/small2/merge-ar
 /test/small2/libmerge.a
 
+*.o
+*.oo

--- a/src/ext/oblivc/obliv_bits.c
+++ b/src/ext/oblivc/obliv_bits.c
@@ -1042,10 +1042,10 @@ void splitYaoProtocolExtra(ProtocolDesc* pdout, ProtocolDesc * pdin) {
     gcry_randomize(ypdout->I,YAO_KEY_BYTES,GCRY_STRONG_RANDOM);
     gcry_randomize(&ypdout->gcount_offset,sizeof(ypdout->gcount_offset),GCRY_STRONG_RANDOM);
     osend(pdout,2,&ypdout->gcount_offset,sizeof(ypdout->gcount_offset));
-    ypdout->sender = honestOTExtSenderAbstract(honestOTExtSenderNew(pdout,2));
+    ypdout->sender = honestOTExtSenderAbstract(honestOTExtSenderSplit(ypdin->sender.sender,pdout));
   } else {
     orecv(pdout,1,&ypdout->gcount_offset,sizeof(ypdout->gcount_offset));
-    ypdout->recver = honestOTExtRecverAbstract(honestOTExtRecverNew(pdout,1));
+    ypdout->recver = honestOTExtRecverAbstract(honestOTExtRecverSplit(ypdin->recver.recver,pdout));
   }
   ypdout->gcount = ypdout->gcount_offset;
   oflush(pdin); oflush(pdout);

--- a/src/ext/oblivc/obliv_bits.c
+++ b/src/ext/oblivc/obliv_bits.c
@@ -1042,10 +1042,10 @@ void splitYaoProtocolExtra(ProtocolDesc* pdout, ProtocolDesc * pdin) {
     gcry_randomize(ypdout->I,YAO_KEY_BYTES,GCRY_STRONG_RANDOM);
     gcry_randomize(&ypdout->gcount_offset,sizeof(ypdout->gcount_offset),GCRY_STRONG_RANDOM);
     osend(pdout,2,&ypdout->gcount_offset,sizeof(ypdout->gcount_offset));
-    ypdout->sender = honestOTExtSenderAbstract(honestOTExtSenderSplit(ypdin->sender.sender,pdout));
+    ypdout->sender = honestOTExtSenderAbstract(honestOTExtSenderSplit(pdout,ypdin->sender.sender));
   } else {
     orecv(pdout,1,&ypdout->gcount_offset,sizeof(ypdout->gcount_offset));
-    ypdout->recver = honestOTExtRecverAbstract(honestOTExtRecverSplit(ypdin->recver.recver,pdout));
+    ypdout->recver = honestOTExtRecverAbstract(honestOTExtRecverSplit(pdout,ypdin->recver.recver));
   }
   ypdout->gcount = ypdout->gcount_offset;
   oflush(pdin); oflush(pdout);

--- a/src/ext/oblivc/obliv_bits.h
+++ b/src/ext/oblivc/obliv_bits.h
@@ -2,6 +2,13 @@
 #define OBLIV_BITS_H
 #define __oblivious_c
 
+/* 
+   Note to maintainers: this header should *never* be included in any other
+   header; it will automatically be included in obliv-c source by the compiler,
+   and it contains defines that should never appear in plain C source (whereas
+   including most other obliv-c headers in regular C source is OK)
+   */
+
 //void* memset(void* s, int c, size_t n); // Hack, had to declare memset
 #include<string.h> // memset to zero
 #include<stdbool.h>

--- a/src/ext/oblivc/obliv_bits.h
+++ b/src/ext/oblivc/obliv_bits.h
@@ -5,8 +5,7 @@
 /* 
    Note to maintainers: this header should *never* be included in any other
    header; it will automatically be included in obliv-c source by the compiler,
-   and it contains defines that should never appear in plain C source (whereas
-   including most other obliv-c headers in regular C source is OK)
+   and it contains defines that should never appear in plain C source.
    */
 
 //void* memset(void* s, int c, size_t n); // Hack, had to declare memset

--- a/src/ext/oblivc/obliv_common.h
+++ b/src/ext/oblivc/obliv_common.h
@@ -74,7 +74,7 @@ void npotRecv1Of2(struct NpotRecver* r,char* dest,const bool* sel,int n,int len,
     int batchsize);
 
 struct HonestOTExtRecver* honestOTExtRecverNew(ProtocolDesc* pd,int srcparty);
-struct HonestOTExtRecver* honestOTExtRecverSplit(struct HonestOTExtRecver* t, ProtocolDesc* pd);
+struct HonestOTExtRecver* honestOTExtRecverSplit(ProtocolDesc* pd,struct HonestOTExtRecver* r_src);
 void honestOTExtRecverRelease(struct HonestOTExtRecver* recver);
 void honestOTExtRecv1Of2(struct HonestOTExtRecver* r,char* dest,const bool* sel,
     int n,int len);
@@ -87,7 +87,7 @@ void honestOTExtRecv1Of2Chunk(void* vargs,char* dest,int nchunk,
     int len,bool isCorr);
 
 struct HonestOTExtSender* honestOTExtSenderNew(ProtocolDesc* pd,int destparty);
-struct HonestOTExtSender* honestOTExtSenderSplit(struct HonestOTExtSender* t, ProtocolDesc* pd);
+struct HonestOTExtSender* honestOTExtSenderSplit(ProtocolDesc* pd,struct HonestOTExtSender* s_src);
 void honestOTExtSenderRelease(struct HonestOTExtSender* sender);
 void honestOTExtSend1Of2(struct HonestOTExtSender* s,
     const char* opt0,const char* opt1,int n,int len);

--- a/src/ext/oblivc/obliv_common.h
+++ b/src/ext/oblivc/obliv_common.h
@@ -74,6 +74,7 @@ void npotRecv1Of2(struct NpotRecver* r,char* dest,const bool* sel,int n,int len,
     int batchsize);
 
 struct HonestOTExtRecver* honestOTExtRecverNew(ProtocolDesc* pd,int srcparty);
+struct HonestOTExtRecver* honestOTExtRecverSplit(struct HonestOTExtRecver* t, ProtocolDesc* pd);
 void honestOTExtRecverRelease(struct HonestOTExtRecver* recver);
 void honestOTExtRecv1Of2(struct HonestOTExtRecver* r,char* dest,const bool* sel,
     int n,int len);
@@ -86,6 +87,7 @@ void honestOTExtRecv1Of2Chunk(void* vargs,char* dest,int nchunk,
     int len,bool isCorr);
 
 struct HonestOTExtSender* honestOTExtSenderNew(ProtocolDesc* pd,int destparty);
+struct HonestOTExtSender* honestOTExtSenderSplit(struct HonestOTExtSender* t, ProtocolDesc* pd);
 void honestOTExtSenderRelease(struct HonestOTExtSender* sender);
 void honestOTExtSend1Of2(struct HonestOTExtSender* s,
     const char* opt0,const char* opt1,int n,int len);

--- a/test/oblivc/protosplit/main.c
+++ b/test/oblivc/protosplit/main.c
@@ -10,24 +10,29 @@ int main(int argc,char* argv[])
 { 
   ProtocolDesc pd;
 
-  if(argc<3)
+  if(argc<5)
   {
     if(argc<2) fprintf(stderr,"Port number missing\n");
     else if(argc<3) fprintf(stderr,"Party missing\n");
-    else fprintf(stderr,"string missing\n");
-    fprintf(stderr,"Usage: %s <port> <--|remote_host>\n",argv[0]);
+    else if(argc<4) fprintf(stderr,"Element Count missing\n");
+    else fprintf(stderr,"Thread Count missing\n");
+    fprintf(stderr,"Usage: %s <port> <--|remote_host> elements threads\n",argv[0]);
     return 1;
   }
 
   const char* remote_host = (strcmp(argv[2],"--")==0?NULL:argv[2]);
   int i, party = (!remote_host?1:2);
 
+  struct args a = {
+    .threads=atoi(argv[4]), .elct=atoi(argv[3])
+  };
+
   //protocolUseStdio(&pd);
   ocTestUtilTcpOrDie(&pd,remote_host,argv[1]);
   setCurrentParty(&pd,party);
 
   lap = wallClock();
-  execYaoProtocol(&pd,goprotosplit,NULL);
+  execYaoProtocol(&pd,goprotosplit,&a);
   fprintf(stderr,"Total time: %lf s\n",wallClock()-lap);
   cleanupProtocol(&pd);
   fprintf(stderr,"\n");

--- a/test/oblivc/protosplit/protosplittest.c
+++ b/test/oblivc/protosplit/protosplittest.c
@@ -1,22 +1,17 @@
 #include "protosplittest.h"
 
-void parallelize(split_fn fn, void * output1, void * output2, void * output3, uint32_t * input, int leneach, void * pd1, void* pd2) {
-	#pragma omp parallel num_threads(3)
+void parallelize(split_fn fn, void * output, uint32_t * input, size_t leneach, size_t threads, void * pds) {
+	omp_set_dynamic(0);
+	omp_set_num_threads(threads);
+	#pragma omp parallel
 	{
-		//OpenMP seems to get along with obliv-c just fine, so long as obliv-c only uses the master thread.
-		#pragma omp master
-		{
-			fn(output1, input, leneach, NULL);
-		}
-		
-
 		#pragma omp single
 		{
-			#pragma omp task
-			fn(output2, &input[leneach], leneach, pd1);
-
-			#pragma omp task
-			fn(output3, &input[2*leneach], leneach, pd2);
+			size_t ii;
+			for (ii = 0; ii < threads; ii++){
+				#pragma omp task
+				fn(output, input, leneach, ii, pds);	
+			}
 		}
 	}
 }

--- a/test/oblivc/protosplit/protosplittest.h
+++ b/test/oblivc/protosplit/protosplittest.h
@@ -3,9 +3,12 @@
 #include <stdbool.h>
 #include <stdio.h>
 
-#define ELCT 2000
+typedef void (* split_fn)(void *, uint32_t *, size_t, size_t, void *);
 
-typedef void (* split_fn)(void *, uint32_t *, int, void *);
+struct args {
+  size_t threads;
+  size_t elct;
+};
 
-void parallelize(split_fn fn, void * output1, void * output2, void * output3, uint32_t * input, int leneach, void * pd1, void* pd2);
+void parallelize(split_fn fn, void * output, uint32_t * input, size_t leneach, size_t threads, void * pds);
 void goprotosplit(void* vargs);

--- a/test/oblivc/protosplit/protosplittest.oc
+++ b/test/oblivc/protosplit/protosplittest.oc
@@ -2,35 +2,43 @@
 #include <obliv_common.h>
 #include "protosplittest.h"
 
-void reducelist(obliv uint32_t * output, uint32_t * inputs, int len, ProtocolDesc * pd) {
-	if (pd != NULL) ocSetCurrentProto(pd);
+void reducelist(obliv uint32_t * output, uint32_t * input, size_t len, size_t index, ProtocolDesc * pds) {
+	ocSetCurrentProto(&pds[index]);
 
 	for (size_t ii = 0; ii < len; ii ++) {
-		*output += feedOblivInt(inputs[ii], ii%2 + 1);
+		obliv uint32_t in = feedOblivInt(input[index*len+ii], ii%2 + 1);
+		output[index] += in;
 	}
 
 	// we want to flush if our protocol is done and other threads are waiting on us
 	// in this case, it's not strictly necessary, but it's a good habit.
-	if (pd != NULL) oflush(pd);
+	oflush(&pds[index]);
 }
 
 void goprotosplit(void* vargs) {
-	obliv uint32_t output1, output2, output3;
+	struct args * a = vargs;
+	fprintf(stdout, "Threads: %d, Elements (each): %u, Total: %u\n", a->threads, a->elct, a->threads * a->elct);
 
-	uint32_t * inputs = malloc(ELCT * 3 * sizeof(uint32_t));
-	for (size_t ii = 0; ii < ELCT*3; ii++) inputs[ii] = ii+1;
+	obliv uint32_t * output = calloc(a->threads, sizeof(obliv uint32_t));
 
-	ProtocolDesc pd1;
-	ocSplitProto(&pd1, ocCurrentProto());
-	ProtocolDesc pd2;
-	ocSplitProto(&pd2, &pd1);
-	parallelize(reducelist, &output1, &output2, &output3, inputs, ELCT, &pd1, &pd2);
-	ocCleanupProto(&pd2);
-	ocCleanupProto(&pd1);
+	uint32_t * input = malloc(a->threads * a->elct * sizeof(uint32_t));
+	for (size_t ii = 0; ii < a->threads * a->elct; ii++) input[ii] = ii+1;
 
-	output1 += output2 + output3;
+	ProtocolDesc * pdorig = ocCurrentProto();	
+	ProtocolDesc * pds = malloc(a->threads * sizeof(ProtocolDesc));
+	for (size_t ii = 0; ii < a->threads; ii++) ocSplitProto(&pds[ii], ocCurrentProto());
+	parallelize(reducelist, output, input, a->elct, a->threads, pds);
+	for (size_t ii = 0; ii < a->threads; ii++) ocCleanupProto(&pds[ii]);
+	ocSetCurrentProto(pdorig);
+
+	for (size_t ii = 1; ii < a->threads; ii++)  {
+		output[0] += output[ii];
+	}
+	
 	uint32_t result;
-	revealOblivInt(&result, output1, 0);
-	printf("Result: %u, Expected: %u\n", result, (ELCT*3+1)*(ELCT*3)/2);
-	free(inputs);
+	revealOblivInt(&result, output[0], 0);
+	fprintf(stdout, "Result: %u, Expected: %u\n", result, (a->elct*a->threads+1)*(a->elct*a->threads)/2);
+	free(input);
+	free(output);
+	free(pds);
 }


### PR DESCRIPTION
Instead of generating new OT extensions, all yao protocols share a single extension box, and use GCC atomics to distribute nonces among themselves without collisions. This saves quite a bit of time (400ms on my machines). Updated the protocol splitting test to allow for testing and benchmarking of this change.