### PR TITLE
Windows port

### DIFF
--- a/src/ext/oblivc/atomic_queue.h
+++ b/src/ext/oblivc/atomic_queue.h
@@ -1,5 +1,6 @@
 #pragma once
 #include<semaphore.h>
+#include<stddef.h>
 #include<stdbool.h>
 
 // What the heck! Why is there no small library already out there for this?

--- a/src/ext/oblivc/obliv.h
+++ b/src/ext/oblivc/obliv.h
@@ -27,6 +27,8 @@ void execDebugProtocol(ProtocolDesc* pd, protocol_run start, void* arg);
 void execNetworkStressProtocol(ProtocolDesc* pd, int bytecount,
                                protocol_run start, void* arg);
 void execYaoProtocol(ProtocolDesc* pd, protocol_run start, void* arg);
+void execYaoProtocol_Init(ProtocolDesc* pd, protocol_run start, void* arg);
+void execYaoProtocol_End(ProtocolDesc* pd, protocol_run start, void* arg);
 void execYaoProtocol_noHalf(ProtocolDesc* pd, protocol_run start, void* arg);
 bool execDualexProtocol(ProtocolDesc* pd, protocol_run start, void* arg);
 bool execNpProtocol(ProtocolDesc* pd, protocol_run start, void* arg);

--- a/src/ext/oblivc/obliv_bits.h
+++ b/src/ext/oblivc/obliv_bits.h
@@ -2,6 +2,11 @@
 #define OBLIV_BITS_H
 #define __oblivious_c
 
+// To compile with x86_64-w64-mingw32-gcc.exe, it's necessary to explictly define the intrinsics from gcc builtins
+#ifdef __CIL_COMPABILITY__
+#include <gcc_builtins.h>
+#endif
+
 //void* memset(void* s, int c, size_t n); // Hack, had to declare memset
 #include<string.h> // memset to zero
 #include<stdbool.h>

--- a/src/ext/oblivc/obliv_common.h
+++ b/src/ext/oblivc/obliv_common.h
@@ -34,8 +34,14 @@ static inline int transSend(ProtocolTransport* t,int d,const void* p,size_t n)
   { return t->send(t,d,p,n); }
 static inline int transRecv(ProtocolTransport* t,int s,void* p,size_t n)
   { return t->recv(t,s,p,n); }
-static inline int transFlush(ProtocolTransport* t)
-  { if (t->flush) return t->flush(t); else return 0; }
+static inline int transFlush(ProtocolTransport* t) {
+#ifndef _WIN32
+  if (t->flush) 
+	  return t->flush(t); 
+  else
+#endif
+	  return 0; 
+}
 static inline int osend(ProtocolDesc* pd,int d,const void* p,size_t n)
   { return transSend(pd->trans,d,p,n); }
 static inline int orecv(ProtocolDesc* pd,int s,void* p,size_t n)

--- a/src/ext/oblivc/obliv_yao.h
+++ b/src/ext/oblivc/obliv_yao.h
@@ -22,6 +22,10 @@ const char* yaoKeyOfBit(const OblivBit* b);
 extern void setupYaoProtocol(ProtocolDesc* pd,bool halfgates);
 extern void mainYaoProtocol(ProtocolDesc* pd, bool point_and_permute,
                             protocol_run start, void* arg);
+extern void mainYaoProtocol_Init(ProtocolDesc* pd, bool point_and_permute,
+                                protocol_run start, void* arg);
+extern void mainYaoProtocol_End(ProtocolDesc* pd, bool point_and_permute,
+                               protocol_run start, void* arg);
 extern void cleanupYaoProtocol(ProtocolDesc* pd);
 extern bool yaoGenrRevealOblivBits(ProtocolDesc* pd,
                 widest_t* dest,const OblivBit* o,size_t n,int party);

--- a/src/ext/oblivc/ot.c
+++ b/src/ext/oblivc/ot.c
@@ -116,7 +116,7 @@ void dhSend(gcry_mpi_point_t u,ProtocolDesc* pd,int party,
 }
 // Allocates a new gcry_mpi_t, and returns it
 gcry_mpi_point_t dhRecv(ProtocolDesc* pd,int party)
-{ char buf[DHEltSerialBytes];
+{ char buf[DHEltSerialBytes] = {};
   gcry_mpi_point_t x;
   orecv(pd,party,buf,DHEltSerialBytes);
   dhDeserialize(&x,buf);

--- a/src/ext/oblivc/psi.c
+++ b/src/ext/oblivc/psi.c
@@ -7,6 +7,7 @@
 #include<obliv_common.h>
 #include<obliv_psi.h>
 #include<stdlib.h>
+#include<sort_r.h> // from https://github.com/noporpoise/sort_r
 
 #define HASH_ALGO GCRY_MD_SHA1
 #define HASH_BITS 160
@@ -173,7 +174,11 @@ OcPsiResult* execPsiProtocol_DH(ProtocolDesc* pd,
   xchgPoints(pd,curve,your,nu,mine,ni);
 
   PointCompareArgs *args = pcaNew(curve);
+#ifdef _WIN32
+  sort_r(your,nu,nu*sizeof(gcry_mpi_point_t),compare_points,args);
+#else
   qsort_r(your,nu,sizeof(*your),compare_points,args);
+#endif
   OcPsiResult* res = ocPsiResultNew(ni<nu?ni:nu);
   for(i=0;i<ni;++i) if(bsearchPoint(mine[i],your,nu,args))
     res->indices[res->n++] = order[i];

--- a/src/ext/oblivc/sort_r.h
+++ b/src/ext/oblivc/sort_r.h
@@ -1,0 +1,226 @@
+/* Isaac Turner 29 April 2014 Public Domain */
+#ifndef SORT_R_H_
+#define SORT_R_H_
+
+#include <stdlib.h>
+#include <string.h>
+
+/*
+
+sort_r function to be exported.
+
+Parameters:
+  base is the array to be sorted
+  nel is the number of elements in the array
+  width is the size in bytes of each element of the array
+  compar is the comparison function
+  arg is a pointer to be passed to the comparison function
+
+void sort_r(void *base, size_t nel, size_t width,
+            int (*compar)(const void *_a, const void *_b, void *_arg),
+            void *arg);
+
+*/
+
+#define _SORT_R_INLINE inline
+
+#if (defined __APPLE__ || defined __MACH__ || defined __DARWIN__ || \
+     defined __FreeBSD__ || defined __DragonFly__)
+#  define _SORT_R_BSD
+#elif (defined _GNU_SOURCE || defined __gnu_hurd__ || defined __GNU__ || \
+       defined __linux__ || defined __MINGW32__ || defined __GLIBC__)
+#  define _SORT_R_LINUX
+#elif (defined _WIN32 || defined _WIN64 || defined __WINDOWS__)
+#  define _SORT_R_WINDOWS
+#  undef _SORT_R_INLINE
+#  define _SORT_R_INLINE __inline
+#else
+  /* Using our own recursive quicksort sort_r_simple() */
+#endif
+
+#if (defined NESTED_QSORT && NESTED_QSORT == 0)
+#  undef NESTED_QSORT
+#endif
+
+/* swap a, b iff a>b */
+/* __restrict is same as restrict but better support on old machines */
+static _SORT_R_INLINE int sort_r_cmpswap(char *__restrict a, char *__restrict b, size_t w,
+                                         int (*compar)(const void *_a, const void *_b,
+                                                       void *_arg),
+                                         void *arg)
+{
+  char tmp, *end = a+w;
+  if(compar(a, b, arg) > 0) {
+    for(; a < end; a++, b++) { tmp = *a; *a = *b; *b = tmp; }
+    return 1;
+  }
+  return 0;
+}
+
+/* Implement recursive quicksort ourselves */
+/* Note: quicksort is not stable, equivalent values may be swapped */
+static _SORT_R_INLINE void sort_r_simple(void *base, size_t nel, size_t w,
+                                         int (*compar)(const void *_a, const void *_b,
+                                                       void *_arg),
+                                         void *arg)
+{
+  char *b = (char *)base, *end = b + nel*w;
+  if(nel < 7) {
+    /* Insertion sort for arbitrarily small inputs */
+    char *pi, *pj;
+    for(pi = b+w; pi < end; pi += w) {
+      for(pj = pi; pj > b && sort_r_cmpswap(pj-w,pj,w,compar,arg); pj -= w) {}
+    }
+  }
+  else
+  {
+    /* nel > 6; Quicksort */
+
+    /* Use median of first, middle and last items as pivot */
+    char *x, *y, *xend, ch;
+    char *pl, *pr;
+    char *last = b+w*(nel-1), *tmp;
+    char *l[3];
+    l[0] = b;
+    l[1] = b+w*(nel/2);
+    l[2] = last;
+
+    if(compar(l[0],l[1],arg) > 0) { tmp=l[0]; l[0]=l[1]; l[1]=tmp; }
+    if(compar(l[1],l[2],arg) > 0) {
+      tmp=l[1]; l[1]=l[2]; l[2]=tmp; /* swap(l[1],l[2]) */
+      if(compar(l[0],l[1],arg) > 0) { tmp=l[0]; l[0]=l[1]; l[1]=tmp; }
+    }
+
+    /* swap l[id], l[2] to put pivot as last element */
+    for(x = l[1], y = last, xend = x+w; x<xend; x++, y++) {
+      ch = *x; *x = *y; *y = ch;
+    }
+
+    pl = b;
+    pr = last;
+
+    while(pl < pr) {
+      for(; pl < pr; pl += w) {
+        if(sort_r_cmpswap(pl, pr, w, compar, arg)) {
+          pr -= w; /* pivot now at pl */
+          break;
+        }
+      }
+      for(; pl < pr; pr -= w) {
+        if(sort_r_cmpswap(pl, pr, w, compar, arg)) {
+          pl += w; /* pivot now at pr */
+          break;
+        }
+      }
+    }
+
+    sort_r_simple(b, (pl-b)/w, w, compar, arg);
+    sort_r_simple(pl+w, (end-(pl+w))/w, w, compar, arg);
+  }
+}
+
+
+#if defined NESTED_QSORT
+
+  static _SORT_R_INLINE void sort_r(void *base, size_t nel, size_t width,
+                                    int (*compar)(const void *_a, const void *_b,
+                                                  void *aarg),
+                                    void *arg)
+  {
+    int nested_cmp(const void *a, const void *b)
+    {
+      return compar(a, b, arg);
+    }
+
+    qsort(base, nel, width, nested_cmp);
+  }
+
+#else /* !NESTED_QSORT */
+
+  /* Declare structs and functions */
+
+  #if defined _SORT_R_BSD
+
+    /* Ensure qsort_r is defined */
+    extern void qsort_r(void *base, size_t nel, size_t width, void *thunk,
+                        int (*compar)(void *_thunk, const void *_a, const void *_b));
+
+  #endif
+
+  #if defined _SORT_R_BSD || defined _SORT_R_WINDOWS
+
+    /* BSD (qsort_r), Windows (qsort_s) require argument swap */
+
+    struct sort_r_data
+    {
+      void *arg;
+      int (*compar)(const void *_a, const void *_b, void *_arg);
+    };
+
+    static _SORT_R_INLINE int sort_r_arg_swap(void *s, const void *a, const void *b)
+    {
+      struct sort_r_data *ss = (struct sort_r_data*)s;
+      return (ss->compar)(a, b, ss->arg);
+    }
+
+  #endif
+
+  #if defined _SORT_R_LINUX
+
+    typedef int(* __compar_d_fn_t)(const void *, const void *, void *);
+    extern void qsort_r(void *base, size_t nel, size_t width,
+                        __compar_d_fn_t __compar, void *arg)
+      __attribute__((nonnull (1, 4)));
+
+  #endif
+
+  /* implementation */
+
+  static _SORT_R_INLINE void sort_r(void *base, size_t nel, size_t width,
+                                    int (*compar)(const void *_a, const void *_b, void *_arg),
+                                    void *arg)
+  {
+    #if defined _SORT_R_LINUX
+
+      #if defined __GLIBC__ && ((__GLIBC__ < 2) || (__GLIBC__ == 2 && __GLIBC_MINOR__ < 8))
+
+        /* no qsort_r in glibc before 2.8, need to use nested qsort */
+        sort_r_simple(base, nel, width, compar, arg);
+
+      #else
+
+        //qsort_r(base, nel, width, compar, arg); // no qsort_r on MinGW
+		sort_r_simple(base, nel, width, compar, arg);
+
+      #endif
+
+    #elif defined _SORT_R_BSD
+
+      struct sort_r_data tmp;
+      tmp.arg = arg;
+      tmp.compar = compar;
+      qsort_r(base, nel, width, &tmp, sort_r_arg_swap);
+
+    #elif defined _SORT_R_WINDOWS
+
+      struct sort_r_data tmp;
+      tmp.arg = arg;
+      tmp.compar = compar;
+      qsort_s(base, nel, width, sort_r_arg_swap, &tmp);
+
+    #else
+
+      /* Fall back to our own quicksort implementation */
+      sort_r_simple(base, nel, width, compar, arg);
+
+    #endif
+  }
+
+#endif /* !NESTED_QSORT */
+
+#undef _SORT_R_INLINE
+#undef _SORT_R_WINDOWS
+#undef _SORT_R_LINUX
+#undef _SORT_R_BSD
+
+#endif /* SORT_R_H_ */


### PR DESCRIPTION
Please note that the configure script may have some issues depending on your system:
	- x86_64-w64-mingw32-gcc.exe (64 bits): detected size_t is "unsigned long long" but the configure doesn't accept it and cil.ml doesn't recognize it. Edit the configure script, search for "real_type=" and explicitly declare it (e.g., "real_type='unsigned long'"). Then run: "./configure CC=x86_64-w64-mingw32-gcc.exe" and "make RELEASE=1"
	- i686-w64-mingw32 (32 bits): if you get the following error message "/usr/i686-w64-mingw32/sys-root/mingw/include/stdlib.h:336: Error: Undefined function", define out the function _abs64:
		#ifdef __MINGW_INTRIN_INLINE
		  __MINGW_INTRIN_INLINE __int64 __cdecl _abs64(__int64 x) { return __builtin_llabs(x);}
		#endif

Steps to generate oblivc.dll and oblivc.lib:

	x86_64-w64-mingw32-gcc.exe -c -g atomic_queue.c -o atomic_queue.o -I .
	x86_64-w64-mingw32-gcc.exe -c -g bcrandom.c -o bcrandom.o -I .
	x86_64-w64-mingw32-gcc.exe -c -g commitReveal.c -o commitReveal.o -I .
	x86_64-w64-mingw32-gcc.exe -c -g dualex.c -o dualex.o -I .
	x86_64-w64-mingw32-gcc.exe -c -g nnob.c -o nnob.o -I .
	x86_64-w64-mingw32-gcc.exe -c -g obliv_bits.c -o obliv_bits.o -I .
	x86_64-w64-mingw32-gcc.exe -c -g obliv_network_utils.c -o obliv_network_utils.o -I .
	x86_64-w64-mingw32-gcc.exe -c -g ot.c -o ot.o -I .
	x86_64-w64-mingw32-gcc.exe -c -g privacy-free.c -o privacy-free.o -I .
	x86_64-w64-mingw32-gcc.exe -c -g psi.c -o psi.o -I .
	x86_64-w64-mingw32-gcc.exe -c -g obliv_float_add.c -o obliv_float_add.o -I .
	x86_64-w64-mingw32-gcc.exe -c -g obliv_float_div.c -o obliv_float_div.o -I .
	x86_64-w64-mingw32-gcc.exe -c -g obliv_float_eq.c -o obliv_float_eq.o -I .
	x86_64-w64-mingw32-gcc.exe -c -g obliv_float_le.c -o obliv_float_le.o -I .
	x86_64-w64-mingw32-gcc.exe -c -g obliv_float_lt.c -o obliv_float_lt.o -I .
	x86_64-w64-mingw32-gcc.exe -c -g obliv_float_mult.c -o obliv_float_mult.o -I .
	x86_64-w64-mingw32-gcc.exe -c -g obliv_float_neg.c -o obliv_float_neg.o -I .
	x86_64-w64-mingw32-gcc.exe -c -g obliv_float_sub.c -o obliv_float_sub.o -I .

	x86_64-w64-mingw32-gcc.exe -shared -g -o oblivc.dll *.o -Wl,--output-def,oblivc.def,--out-implib,oblivc.a -lgcrypt -pthread -lws2_32

	lib /machine:x64 /def:oblivc.def

Compiling with Obliv-C:
	Please note that the CIL compiler underlying Obliv-C doesn't support intrinsics: you may have to comment/define out all the intrinsics definitions from system's headers (e.g., avx512fintrin.h, avxintrin.h, emmintrin.h, f16cintrin.h, mm3dnow.h, xmmintrin.h)