### PR TITLE
Support large batch OT size for `honestOTExtSend1Of2Chunk`

### DIFF
--- a/bin/oblivcc
+++ b/bin/oblivcc
@@ -3,6 +3,7 @@ OCCPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../ && pwd )"
 OCLIB=$OCCPATH/src/ext/oblivc
 COMPILE_ONLY=0
 CCARGS=""
+AFTERARGS=""
 CILLYARGS=""
 OCSRC=()
 GCRYPT="-lgcrypt"
@@ -12,26 +13,15 @@ else
   OBLIV_BITS="-include obliv_bits.h"
 fi
 
-while [ $# -ge 1 ]; do
-  if [ "$1" = "-static-gcrypt" ]; then
-    GCRYPT="/usr/lib/x86_64-linux-gnu/libgcrypt.a -lgpg-error"
-  else
-    CCARGS+="$1 "
-  fi
-  shift
-done
-
 set -e
-$OCCPATH/bin/cilly -Wno-format-security -Wno-deprecated-declarations --keepunused --doprocessObliv --markImplicitCasts $OBLIV_BITS -I $OCLIB -L$OCCPATH/_build -lobliv $GCRYPT -pthread $CCARGS
 
-if false; then
 while [ $# -ge 1 ]; do
   if [ "$1" = "-c" ]; then
     COMPILE_ONLY=1
     CCARGS+="-c "
   elif [ "$1" = "-static-gcrypt" ]; then
     GCRYPT="/usr/lib/x86_64-linux-gnu/libgcrypt.a -lgpg-error"
-  elif [ "${1%.oc}" != "$1" ]; then
+  elif [[ "$1" == *oc ]]; then
     OCSRC+=($1)
     CCARGS+="$1.cil.c "
   else
@@ -43,6 +33,9 @@ while [ $# -ge 1 ]; do
       CILLYARGS+="-I $2 "
       CCARGS+="-I $2 "
       shift
+    elif [[ "$1" == -l* ]]; then
+      CCARGS+="$1 "
+      AFTERARGS+="$1 "
     else
       CCARGS+="$1 "
     fi
@@ -58,5 +51,4 @@ for src in ${OCSRC[*]}; do
   $OCCPATH/bin/cilobliv $src -I $OCLIB $CILLYARGS || exit
 done
 
-gcc $CCARGS -I $OCLIB -Wno-format-security -Wno-deprecated-declarations -lobliv -O3 -L$OCCPATH/_build $GCRYPT -pthread
-fi
+gcc $CCARGS -I $OCLIB -Wno-format-security -Wno-deprecated-declarations -lobliv -O3 -L$OCCPATH/_build $GCRYPT $AFTERARGS -pthread

--- a/src/ext/oblivc/ot.c
+++ b/src/ext/oblivc/ot.c
@@ -1059,7 +1059,7 @@ typedef struct
   void* sender;
 } SendMsgArgs;
 
-#define MSGBUFFER_SIZE 10000
+#define MSGBUFFER_SIZE 2500
 static void sendBufFlush(SendMsgArgs* a)
 {
   transSend(a->trans,a->destParty,a->buf,a->bufused);

--- a/src/ext/oblivc/ot.c
+++ b/src/ext/oblivc/ot.c
@@ -1075,7 +1075,7 @@ static void sendBufSend(SendMsgArgs* a,const char* data)
 static void sendBufInit(SendMsgArgs* a)
 {
   size_t bufsize = a->len;
-  bufsize * = MSGBUFFER_SIZE;
+  bufsize *= MSGBUFFER_SIZE;
   a->buf=malloc(bufsize);
   a->bufused=0;
 }

--- a/src/ext/oblivc/ot.c
+++ b/src/ext/oblivc/ot.c
@@ -1049,7 +1049,7 @@ bcipherCryptNoResize(BCipherRandomGen* gen,const char* key,int nonce,
 typedef struct
 { BCipherRandomGen *cipher;
   const char *box;
-  int n, rowBytes, *rows, k, nonce, nonceDelta, len, destParty, c;
+  int n, rowBytes, *rows, k, nonce, nonceDelta, destParty, c;
   size_t len;
   char *opt0, *opt1;
   const char *spack;
@@ -1144,7 +1144,7 @@ static void recvBufRecv(RecvMsgArgs* a,char* data)
 static void recvBufInit(RecvMsgArgs* a)
 {
   a->buf=malloc(a->len*MSGBUFFER_SIZE);
-  a->bufread=bufsize;
+  a->bufread=a->len*MSGBUFFER_SIZE;
   a->payloadLeft=(a->isCorr?a->n:2*a->n);
 }
 static void recvBufRelease(RecvMsgArgs* a) { free(a->buf); }

--- a/src/ext/oblivc/ot.c
+++ b/src/ext/oblivc/ot.c
@@ -1050,6 +1050,7 @@ typedef struct
 { BCipherRandomGen *cipher;
   const char *box;
   int n, rowBytes, *rows, k, nonce, nonceDelta, len, destParty, c;
+  size_t len;
   char *opt0, *opt1;
   const char *spack;
   ProtocolTransport *trans;
@@ -1068,15 +1069,13 @@ static void sendBufFlush(SendMsgArgs* a)
 
 static void sendBufSend(SendMsgArgs* a,const char* data)
 {
-  if(a->bufused>=(size_t)(a->len)*MSGBUFFER_SIZE) sendBufFlush(a);
+  if(a->bufused>=a->len*MSGBUFFER_SIZE) sendBufFlush(a);
   memcpy(a->buf+a->bufused,data,a->len);
   a->bufused+=a->len;
 }
 static void sendBufInit(SendMsgArgs* a)
 {
-  size_t bufsize = a->len;
-  bufsize *= MSGBUFFER_SIZE;
-  a->buf=malloc(bufsize);
+  a->buf=malloc(a->len*MSGBUFFER_SIZE);
   a->bufused=0;
 }
 static void sendBufRelease(SendMsgArgs* a) { sendBufFlush(a); free(a->buf); }
@@ -1119,7 +1118,8 @@ senderExtensionBoxSendMsg(SendMsgArgs* a)
 typedef struct
 { BCipherRandomGen *cipher;
   const char *box;
-  int n, rowBytes, *rows, k, nonce, nonceDelta, len, srcParty, c;
+  int n, rowBytes, *rows, k, nonce, nonceDelta, srcParty, c;
+  size_t len;
   char *msg;
   const char *mask; // Receiver's selections
   ProtocolTransport *trans;
@@ -1130,22 +1130,20 @@ typedef struct
 static void recvBufFill(RecvMsgArgs* a)
 {
   int n = (a->payloadLeft<MSGBUFFER_SIZE?a->payloadLeft:MSGBUFFER_SIZE);
-  transRecv(a->trans,a->srcParty,a->buf,n*(size_t)(a->len));
+  transRecv(a->trans,a->srcParty,a->buf,n*a->len);
   a->bufread=0;
 }
 
 static void recvBufRecv(RecvMsgArgs* a,char* data)
 {
-  if(a->bufread>=(size_t)(a->len)*MSGBUFFER_SIZE) recvBufFill(a);
+  if(a->bufread>=a->len*MSGBUFFER_SIZE) recvBufFill(a);
   memcpy(data,a->buf+a->bufread,a->len);
   a->bufread+=a->len;
   a->payloadLeft--;
 }
 static void recvBufInit(RecvMsgArgs* a)
 {
-  size_t bufsize = a->len;
-  bufsize *= MSGBUFFER_SIZE;
-  a->buf=malloc(bufsize);
+  a->buf=malloc(a->len*MSGBUFFER_SIZE);
   a->bufread=bufsize;
   a->payloadLeft=(a->isCorr?a->n:2*a->n);
 }


### PR DESCRIPTION
This PR changes some `int`-type size to `size_t`-type size in the OT for `honestOTExtSend1Of2Chunk`.

Therefore, it can support large batch OT size. 

Previously, the size may go to a negative int before calling `malloc`. 
When it converts to `size_t`, it is negative, too. 
So if you ask for 4GB, it becomes several EBs. 

This PR also resolves the failure of Square-Root ORAM for large block sizes.
More details of that issue: https://github.com/samee/sqrtOram/issues/3

Tested with floram sqrtOram benchmark. 