### PR TITLE
Fix minor build script bug

### DIFF
--- a/bin/oblivcc
+++ b/bin/oblivcc
@@ -1,5 +1,5 @@
 #!/bin/bash
-OCCPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../ && pwd )"
+OCCPATH="$(>/dev/null cd "$( dirname "${BASH_SOURCE[0]}" )"/../ && pwd )"
 OCLIB=$OCCPATH/src/ext/oblivc
 COMPILE_ONLY=0
 CCARGS=""


### PR DESCRIPTION
It turns out that if `CDPATH` is set, `cd` always outputs the cwd, which messes up some paths in the oblivcc script. This simply pipes the output of `cd` to `/dev/null` so that we only get the output of `pwd` in the variable.