### PR TITLE
fix `processObliv` dropping labels from CIL && ||

### DIFF
--- a/src/ext/processObliv/processObliv.ml
+++ b/src/ext/processObliv/processObliv.ml
@@ -802,8 +802,10 @@ class codegenVisitor (curFunc : fundec) (dt:depthTracker) (curCond : lval)
     let isDeepVar v = dt#curDepth() = dt#varDepth v in
     match s.skind with
     | Instr ilist -> 
+        let num = List.length ilist in
         let nestedGen = codegenInstr curCond tmpVar isDeepVar in
-        ChangeTo (mkStmt (Instr (mapcat nestedGen ilist)))
+        if num == 0 then DoChildren
+        else ChangeTo (mkStmt (Instr (mapcat nestedGen ilist)))
     | If(c,tb,fb,loc) when isOblivBlock tb ->
         let cond = "__obliv_c__cond" in
         let cv = var (tmpVar ~name:cond oblivBoolType) in

--- a/src/ext/processObliv/processObliv.ml
+++ b/src/ext/processObliv/processObliv.ml
@@ -802,10 +802,12 @@ class codegenVisitor (curFunc : fundec) (dt:depthTracker) (curCond : lval)
     let isDeepVar v = dt#curDepth() = dt#varDepth v in
     match s.skind with
     | Instr ilist -> 
+        let mkStmt_with_label (sk: stmtkind) (lb: label list) : stmt =
+        { skind = sk; labels = lb; sid = -1; succs = []; preds = [] } in
         let num = List.length ilist in
         let nestedGen = codegenInstr curCond tmpVar isDeepVar in
         if num == 0 then DoChildren
-        else ChangeTo (mkStmt (Instr (mapcat nestedGen ilist)))
+        else ChangeTo (mkStmt_with_label (Instr (mapcat nestedGen ilist)) s.labels)
     | If(c,tb,fb,loc) when isOblivBlock tb ->
         let cond = "__obliv_c__cond" in
         let cv = var (tmpVar ~name:cond oblivBoolType) in


### PR DESCRIPTION
CIL may generate `goto` and labels from && || in some cases (see https://people.eecs.berkeley.edu/~necula/cil/cil004.html).

However, due to an implementation detail, `processObliv` drops the label, causing `gcc`'s compiler error.

This fix corrects the `codegenVisitor` when dealing `statement` with empty list. Such statement cannot be regenerated by the information in the list, and should not be reconstructed.