### PR TITLE
Fix C++ compatibility issue

### DIFF
--- a/src/ext/oblivc/obliv_common.h
+++ b/src/ext/oblivc/obliv_common.h
@@ -130,7 +130,13 @@ static inline bool getBit(const char* src,int ind)
   { return src[ind/8]&(1<<ind%8); }
 static inline void xorBit(char *dest,int ind,bool v)
   { dest[ind/8]^=(v<<ind%8); }
+
+// C++ doesn't have the restrict keyword
+#ifdef __cplusplus
+static inline void memxor(void *dest, const void *src, size_t n) {
+#else
 static inline void memxor(void *restrict dest, const void *restrict src, size_t n) {
+#endif
   for(size_t i = 0; i < n; i++) {
     ((char *) dest)[i] ^= ((char *)src)[i];
   }


### PR DESCRIPTION
Remove the `restrict` keyword if obliv_common.h is included in C++ code. Ideally, that would never be needed in the first place, but there are some strange dependencies (e.g. via bcrandom.h)