### PR TITLE
reduces the total RTT for revealOblivBoolArray

### DIFF
--- a/src/ext/oblivc/obliv_bits.c
+++ b/src/ext/oblivc/obliv_bits.c
@@ -2102,8 +2102,12 @@ bool revealOblivBool(bool * dest, __obliv_c__bool src, int party)
 bool revealOblivBoolArray(bool *dest, const __obliv_c__bool * src,
                               size_t n, int party)
 { bool rv = true;
-  for (size_t ii = 0; ii < n; ii++)
-    { rv &= revealOblivBool(&dest[ii], src[ii], party); }
+  if(party != 1) 
+    for (size_t ii = 0; ii < n; ii++) 
+      { rv &= revealOblivBool(&dest[ii], src[ii], 2); }
+  if(party != 2)
+    for (size_t ii = 0; ii < n; ii++)
+      { rv &= revealOblivBool(&dest[ii], src[ii], 1); }
   return rv;
 }
 


### PR DESCRIPTION
When we reveal data to both parties, we may use `revealOblivBoolArray`. It passes `party=0` to the underlying function. There are many rounds due to underlying implementations.

This commit changes the way `revealOblivBoolArray` deals with an array to the same way used by `revealObliv##tnameArray`, which uses `party=2` to reveal the result to the second party first, and then uses `party=1` to reveal to the first party, rather than uses `party=0`.

It reduces the total RTT.

I tested the change with the following script:
```
#include<obliv.h>
#include <obliv.oh>
#include<stdio.h>
#include<stdlib.h>
#include<time.h>

double wallClock()
{
  struct timespec t;
  clock_gettime(CLOCK_REALTIME,&t);
  return t.tv_sec+1e-9*t.tv_nsec;
}

void ocTestUtilTcpOrDie(ProtocolDesc* pd,const char* remote_host,
                        const char* port)
{
  if(!remote_host)
  { if(protocolAcceptTcp2P(pd,port)!=0)
    { fprintf(stderr,"TCP accept failed\n");
      exit(1);
    }
  }
  else 
    if(protocolConnectTcp2P(pd,remote_host,port)!=0) 
    { fprintf(stderr,"TCP connect failed\n");
      exit(1);
    }
}


double lap;

#define MAXN 1000
void readBool(obliv bool* dest, int n, const bool* src,int party)
{
	OblivInputs specs[MAXN];
	int i;
	for(i=0;i<n;++i) setupOblivBool(specs+i,dest+i,src[i]);
	feedOblivInputs(specs,n,party);
}

void gotest(void* vargs)
{
	obliv bool p1_input[1000];
	obliv bool p2_input;

	bool buf[1000];
	readBool(p1_input, 1000, buf, 1);
	readBool(&p2_input, 1, buf, 2);

	fprintf(stderr,"OT time: %lf s\n",wallClock()-lap);

	for(int i = 0; i < 1000; i++){
		p1_input[i] = p1_input[i] ^ p2_input;
	}
        // no party knows

        // original version
        // for(int i = 0; i < 1000; ++i) revealOblivBool(buf + i, p1_input[i], 0);

        // improved version
	revealOblivBoolArray(buf, p1_input, 1000, 0);
}

int main(int argc,char* argv[])
{ 
  ProtocolDesc pd;

  const char* remote_host = (strcmp(argv[2],"--")==0?NULL:argv[2]);
  int i, party = (!remote_host?1:2);

  ocTestUtilTcpOrDie(&pd,remote_host,argv[1]);
  setCurrentParty(&pd,party);

  lap = wallClock();
  execYaoProtocol(&pd, gotest, NULL);
  fprintf(stderr,"Total time: %lf s\n",wallClock()-lap);
  cleanupProtocol(&pd);
  fprintf(stderr,"\n");
  return 0;
}
```

The original version:
```
OT time: 0.628520 s
Total time: 22.787672 s
```

The improved version:
```
OT time: 0.586414 s
Total time: 0.586716 s
```