### PR TITLE
fix macos build problem related to finding libgcrypt

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -37,6 +37,7 @@ stamp-h: config.h.in config.status
 
 CC=@CC@
 CPP=@CPP@
+CFLAGS=@CFLAGS@
 @DEFAULT_COMPILER@=1
 
 # We have to use _build because of OCaml's bug #0004502
@@ -106,9 +107,9 @@ $(OCAMLBUILD_TARGETS): ocamlbuild
 
 # ------ these lines were added for obliv-C runtime -----------
 ifeq ($(DEBUG),1)
-  CFLAGS=-g
+  CFLAGS += -g
 else
-  CFLAGS=-O3
+  CFLAGS += -O3
 endif
 DEPENDDIR = $(OBJDIR)/depends
 OCSRCDIR = src/ext/oblivc

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Obliv-C is a simple GCC wrapper that makes it easy to embed secure computation p
 # Installation
 Unfortunately, the instructions for Fedora and Mac OS might be a little out of date, since we discovered OPAM is now a dependency (#49). Please ping us if you figured out how to install Obliv-C on those systems.
 
-1. Installation of dependencies. 
+1. Installation of dependencies.
   * For Ubuntu: `sudo apt-get install ocaml libgcrypt20-dev ocaml-findlib opam m4`.
   * For Fedora 27: `sudo dnf install glibc-devel.i686 ocaml ocaml-ocamldoc ocaml-findlib ocaml-findlib-devel ocaml-ocamlbuild libgcrypt libgcrypt-devel perl-ExtUtils-MakeMaker perl-Data-Dumper`.
   * For Mac OS (with Macports): `sudo port install gcc5 ocaml ocaml-findlib opam libgcrypt +devel`.
@@ -23,7 +23,7 @@ Unfortunately, the instructions for Fedora and Mac OS might be a little out of d
 
 3. Git-clone this repository, and compile:
   * For Linux: `./configure && make`.
-  * For Mac OS (with Macports): `CC=/opt/local/bin/gcc-mp-5 CPP=/opt/local/bin/cpp-mp-5 LIBRARY_PATH=/opt/local/lib ./configure && make`.
+  * For Mac OS (with Macports): `CC=/opt/local/bin/gcc-mp-5 CPP=/opt/local/bin/cpp-mp-5 CFLAGS=/opt/local/include LIBRARY_PATH=/opt/local/lib ./configure && make`.
 
 4. Start using it! The compiler is a GCC wrapper script found in `bin/oblivcc`. Example codes are in `test/oblivc`. A language tutorial is found [here](http://goo.gl/TXzxD0).
 
@@ -31,7 +31,7 @@ Most of this code was forked from the project CIL (C Intermediate Language). You
 
 # Benchmarks
 
-This repository includes several example programs using Obliv-C in the `test/oblivc` directory.  See [obliv-c/test/oblivc/README.txt](https://github.com/uvasrg/obliv-c/blob/obliv-c/test/oblivc/README.txt) for details. 
+This repository includes several example programs using Obliv-C in the `test/oblivc` directory.  See [obliv-c/test/oblivc/README.txt](https://github.com/samee/obliv-c/blob/obliv-c/test/oblivc/README.txt) for details.
 
 # Help
 

--- a/test/oblivc/README.txt
+++ b/test/oblivc/README.txt
@@ -10,7 +10,7 @@ Folders:
 
 To run these tests (assuming the project has been already built), you should
 just go to the folder and run the respective Makefile. This should give you
-a self-contained 'a.out' executable. Run it without parameters to see usage 
+a self-contained 'a.out' executable. Run it without parameters to see usage
 details. E.g. to run editdist:
 
   $ cd editdist
@@ -22,6 +22,11 @@ details. E.g. to run editdist:
   $ ./a.out 1234 localhost left
   <...>
   Result: 2
+
+Note: For a non-standard library location for libgcrypt, you can pass a
+environment variable like this for MacOS:
+
+  $ CFLAGS="-I/opt/local/include -L/opt/local/lib" make
 
 The make command simply builds 'a.out'. When you run it, it complains about
 missing parameters, and then prints out the usage detail. The next two commands
@@ -38,7 +43,7 @@ for a connection. The second command starts up the client on the same machine
 and connects to the server on "localhost", port "1234". It uses the string
 "left" as its input. As a client, it is configured to act as the evaluator in
 the protocol.  They both output "Result: 2" with a bunch of other stats about
-the runtime. 
+the runtime.
 
 Currently, hamming test also asks for a <proto> parameter. For now, "yao" is the
 only valid value for this parameter. We sometimes use it to test out other

--- a/test/oblivc/common/Makefile.simple
+++ b/test/oblivc/common/Makefile.simple
@@ -1,7 +1,7 @@
 $(if $(testName),,$(error 'testName' must be defined before Makefile.simple is used))
 CILPATH=../../../
 REMOTE_HOST=localhost
-CFLAGS=-DREMOTE_HOST=$(REMOTE_HOST) -O3
+CFLAGS += -DREMOTE_HOST=$(REMOTE_HOST) -O3
 ./a.out: $(testName).oc $(testName).c ../common/util.c $(CILPATH)/_build/libobliv.a
 	$(CILPATH)/bin/oblivcc $(CFLAGS) -I . $(testName).oc $(testName).c ../common/util.c
 clean:


### PR DESCRIPTION
Hello,

This fixes a problem with building obliv-c for macos where it couldn't find the libgcrypt library. I ended up having to modify the Makefile.in file but I'm pretty sure that is suppose to be generated from another file such as a Makefile.am but couldn't find one. If this fix doesn't make sense let me know how I can fix this properly.

Thanks!