### PR TITLE
Fix assignment of clear float values to obliv floats

### DIFF
--- a/src/ext/oblivc/obliv_bits.h
+++ b/src/ext/oblivc/obliv_bits.h
@@ -192,9 +192,9 @@ void __obliv_c__condAssignKnown(const void* cond, void* dest, size_t size
 // Conditionals (TODO other operators) that may be faster at times
 static inline 
 void __obliv_c__condAssignKnownF(const void* cond, void* dest, size_t size
-                                ,widest_t val)
+                                ,float val)
 {
-  OblivBit ov[__bitsize(widest_t)];
+  OblivBit ov[__bitsize(float)];
   __obliv_c__setFloatKnown(ov,size,val);
   __obliv_c__ifThenElse(dest,ov,dest,size,cond);
 }

--- a/src/ext/processObliv/processObliv.ml
+++ b/src/ext/processObliv/processObliv.ml
@@ -562,22 +562,22 @@ let condSetKnownInt c v k x loc =
 let setKnownFloat v k x loc =
   let fargTypes = ["dest",TPtr(typeOfLval v,[]),[]
                 ;"bitcount",!typeOfSizeOf,[]
-                ;"value",widestType,[]
+                ;"value",TFloat(k,[]),[]
                 ] in
   let func = voidFunc "__obliv_c__setFloatKnown" fargTypes in
   Call(None,func,[ AddrOf v; xoBitsSizeOf (TFloat(k,[]))
-               ; CastE(widestType,CastE(TFloat(k,[]),x))
+               ; CastE(TFloat(k,[]),x)
                ],loc)
 
 let condSetKnownFloat c v k x loc =
   let fargTypes = ["cond",TPtr(oblivBoolType,[]),[]
                   ;"dest",TPtr(typeOfLval v,[]),[]
                   ;"size",!typeOfSizeOf,[]
-                  ;"val",widestType,[]
+                  ;"val",TFloat(k,[]),[]
                   ] in
   let func = voidFunc "__obliv_c__condAssignKnownF" fargTypes in
   Call(None,func,[ mkAddrOf c; mkAddrOf v; xoBitsSizeOf (TFloat(k,[]))
-                 ; CastE(widestType,CastE(TFloat(k,[]),x))
+                 ; CastE(TFloat(k,[]),x)
                  ],loc)
 
 let setIfThenElse dest c ts fs loc = 


### PR DESCRIPTION
Casting to `widest_t` seems truncate the inputs. An example that did not work before this change:
```
obliv float z = 0.5f;
float z_clear;
revealOblivFloat(&z_clear, z, 0);
printf("expected 0.5, got %f\n", z_clear);
```

Output before:
```expected 0.5, got 0.000000```

Output now:
```expected 0.5, got 0.500000```

Fixes #85 